### PR TITLE
add defer func to log metrics for instrumented funcs

### DIFF
--- a/examples/web/cmd/main.go
+++ b/examples/web/cmd/main.go
@@ -25,7 +25,7 @@ func main() {
 
 	http.HandleFunc("/", errorable(indexHandler))
 	http.HandleFunc("/random-error", errorable(randomErrorHandler))
-	// TODO: add a "/metrics" handler
+
 	// Expose /metrics HTTP endpoint using the created custom registry.
 	http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{Registry: reg}))
 

--- a/pkg/autometrics/instrument.go
+++ b/pkg/autometrics/instrument.go
@@ -3,13 +3,28 @@ package autometrics
 import (
 	"runtime"
 	"strings"
+	"time"
 )
 
-func Instrument() {
+func Instrument(startTime time.Time, err *error) {
+	method, module := callerInfo()
+	result := "ok"
+
+	if err != nil && *err != nil {
+		result = "error"
+	}
+
+	FunctionCallsCount.WithLabelValues(method, module, result).Inc()
+	FunctionCallsDuration.WithLabelValues(method, module).Observe(time.Since(startTime).Seconds())
+	FunctionCallsConcurrent.WithLabelValues(method, module).Dec()
+}
+
+func PreInstrument() time.Time {
 	method, module := callerInfo()
 
-	println(method)
-	println(module)
+	FunctionCallsConcurrent.WithLabelValues(method, module).Inc()
+
+	return time.Now()
 }
 
 // callerInfo returns the (method name, module name) of the function that called the function that called this function

--- a/pkg/autometrics/main.go
+++ b/pkg/autometrics/main.go
@@ -6,43 +6,26 @@ import (
 )
 
 var (
-	FunctionCallsCount      *prometheus.Counter
-	FunctionCallsDuration   *prometheus.Histogram
-	FunctionCallsConcurrent *prometheus.Gauge
+	FunctionCallsCount      *prometheus.CounterVec
+	FunctionCallsDuration   *prometheus.HistogramVec
+	FunctionCallsConcurrent *prometheus.GaugeVec
 )
 
 // Init sets up the metrics required for autometrics' decorated functions
 func Init(reg *prometheus.Registry) {
-	functionCallsCounter := promauto.NewCounter(prometheus.CounterOpts{
+	FunctionCallsCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "function_calls_count",
-		ConstLabels: map[string]string{
-			"function": "",
-			"module":   "",
-		},
-	})
+	}, []string{"function", "module", "result"})
 
-	functionCallDuration := promauto.NewHistogram(prometheus.HistogramOpts{
+	FunctionCallsDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "function_calls_duration",
-		ConstLabels: map[string]string{
-			"function": "",
-			"module":   "",
-		},
-	})
+	}, []string{"function", "module"})
 
-	functionCallsConcurrent := promauto.NewGauge(prometheus.GaugeOpts{
+	FunctionCallsConcurrent = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "function_calls_concurrent",
-		ConstLabels: map[string]string{
-			"function": "",
-			"module":   "",
-		},
-	})
+	}, []string{"function", "module"})
 
-	reg.MustRegister(functionCallsCounter)
-	reg.MustRegister(functionCallDuration)
-	reg.MustRegister(functionCallsConcurrent)
-
-	// need to do it in two steps so the variable isn't homeless: https://stackoverflow.com/a/10536096/11494565
-	FunctionCallsCount = &functionCallsCounter
-	FunctionCallsDuration = &functionCallDuration
-	FunctionCallsConcurrent = &functionCallsConcurrent
+	reg.MustRegister(FunctionCallsCount)
+	reg.MustRegister(FunctionCallsDuration)
+	reg.MustRegister(FunctionCallsConcurrent)
 }


### PR DESCRIPTION
fixes #2. the generator should insert the following at the start of an instrumented function:

```go
defer autometrics.Instrument(autometrics.PreInstrument(), &err)
```