### PR TITLE
Fix link generation in doc

### DIFF
--- a/examples/web/cmd/main.go
+++ b/examples/web/cmd/main.go
@@ -33,29 +33,34 @@ func main() {
 //
 // It always succeeds and says hello.
 //
-//	autometrics:doc-start DO NOT EDIT
+//	autometrics:doc-start DO NOT EDIT HERE AND LINE ABOVE
 //
 // # Autometrics
 //
 // ## Prometheus
 //
 // View the live metrics for the `indexHandler` function:
-//   - [Request Rate](http://localhost:9090/graph?g0.expr=%23+Rate+of+calls+to+the+%60indexHandler%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_counter%7Bfunction%3D%22indexHandler%22%7D%5B5m%5D%29%29&g0.tab=0)
-//   - [Error Ratio](http://localhost:9090/graph?g0.expr=%23+Percentage+of+calls+to+the+%60indexHandler%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_counter%7Bfunction%3D%22indexHandler%22%2Cresult%3D%22error%22%7D%5B5m%5D%29%29&g0.tab=0)
-//   - [Latency (95th and 99th percentiles)](http://localhost:9090/graph?g0.expr=%23+95th+and+99th+percentile+latencies+%28in+seconds%29+for+the+%60indexHandler%60+function%0A%0Ahistogram_quantile%280.99%2C+sum+by+%28le%2C+function%2C+module%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22indexHandler%22%7D%5B5m%5D%29%29%29+or+histogram_quantile%280.95%2C+sum+by+%28le%2C+function%2C+module%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22indexHandler%22%7D%5B5m%5D%29%29%29&g0.tab=0)
-//   - [Concurrent Calls](http://localhost:9090/graph?g0.expr=%23+Concurrent+calls+to+the+%60indexHandler%60+function%0A%0Asum+by+%28function%2C+module%29+function_calls_concurrent%7Bfunction%3D%22indexHandler%22%7D&g0.tab=0)
+//   - [Request Rate]
+//   - [Error Ratio]
+//   - [Latency (95th and 99th percentiles)]
+//   - [Concurrent Calls]
 //
 // Or, dig into the metrics of *functions called by* `indexHandler`
+//   - [Request Rate Callee]
+//   - [Error Ratio Callee]
 //
-//   - [Request Rate](http://localhost:9090/graph?g0.expr=%23+Rate+of+function+calls+emanating+from+%60indexHandler%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_counter%7Bcaller%3D%22indexHandler%22%7D%5B5m%5D%29%29&g0.tab=0)
+//	autometrics:doc-end DO NOT EDIT HERE AND LINE BELOW
 //
-//   - [Error Ratio](http://localhost:9090/graph?g0.expr=%23+Percentage+of+function+emanating+from+%60indexHandler%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_counter%7Bcaller%3D%22indexHandler%22%2Cresult%3D%22error%22%7D%5B5m%5D%29%29&g0.tab=0)
-//
-//     autometrics:doc-end DO NOT EDIT
+// [Request Rate]: http://localhost:9090/graph?g0.expr=%23+Rate+of+calls+to+the+%60indexHandler%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_count%7Bfunction%3D%22indexHandler%22%7D%5B5m%5D%29%29&g0.tab=0
+// [Error Ratio]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+calls+to+the+%60indexHandler%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_count%7Bfunction%3D%22indexHandler%22%2Cresult%3D%22error%22%7D%5B5m%5D%29%29&g0.tab=0
+// [Latency (95th and 99th percentiles)]: http://localhost:9090/graph?g0.expr=%23+95th+and+99th+percentile+latencies+%28in+seconds%29+for+the+%60indexHandler%60+function%0A%0Ahistogram_quantile%280.99%2C+sum+by+%28le%2C+function%2C+module%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22indexHandler%22%7D%5B5m%5D%29%29%29+or+histogram_quantile%280.95%2C+sum+by+%28le%2C+function%2C+module%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22indexHandler%22%7D%5B5m%5D%29%29%29&g0.tab=0
+// [Concurrent Calls]: http://localhost:9090/graph?g0.expr=%23+Concurrent+calls+to+the+%60indexHandler%60+function%0A%0Asum+by+%28function%2C+module%29+function_calls_concurrent%7Bfunction%3D%22indexHandler%22%7D&g0.tab=0
+// [Request Rate Callee]: http://localhost:9090/graph?g0.expr=%23+Rate+of+function+calls+emanating+from+%60indexHandler%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_count%7Bcaller%3D%22main.indexHandler%22%7D%5B5m%5D%29%29&g0.tab=0
+// [Error Ratio Callee]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+function+emanating+from+%60indexHandler%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_count%7Bcaller%3D%22main.indexHandler%22%2Cresult%3D%22error%22%7D%5B5m%5D%29%29&g0.tab=0
 //
 //autometrics:doc
 func indexHandler(w http.ResponseWriter, _ *http.Request) (err error) {
-        defer autometrics.Instrument(autometrics.PreInstrument(), &err) //autometrics:defer-statement
+	defer autometrics.Instrument(autometrics.PreInstrument(), &err) //autometrics:defer-statement
 	_, err = fmt.Fprintf(w, "Hello, World!\n")
 	return
 }
@@ -66,29 +71,34 @@ var handlerError = errors.New("failed to handle request")
 //
 // It returns an error around 50% of the time.
 //
-//	autometrics:doc-start DO NOT EDIT
+//	autometrics:doc-start DO NOT EDIT HERE AND LINE ABOVE
 //
 // # Autometrics
 //
 // ## Prometheus
 //
 // View the live metrics for the `randomErrorHandler` function:
-//   - [Request Rate](http://localhost:9090/graph?g0.expr=%23+Rate+of+calls+to+the+%60randomErrorHandler%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_counter%7Bfunction%3D%22randomErrorHandler%22%7D%5B5m%5D%29%29&g0.tab=0)
-//   - [Error Ratio](http://localhost:9090/graph?g0.expr=%23+Percentage+of+calls+to+the+%60randomErrorHandler%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_counter%7Bfunction%3D%22randomErrorHandler%22%2Cresult%3D%22error%22%7D%5B5m%5D%29%29&g0.tab=0)
-//   - [Latency (95th and 99th percentiles)](http://localhost:9090/graph?g0.expr=%23+95th+and+99th+percentile+latencies+%28in+seconds%29+for+the+%60randomErrorHandler%60+function%0A%0Ahistogram_quantile%280.99%2C+sum+by+%28le%2C+function%2C+module%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22randomErrorHandler%22%7D%5B5m%5D%29%29%29+or+histogram_quantile%280.95%2C+sum+by+%28le%2C+function%2C+module%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22randomErrorHandler%22%7D%5B5m%5D%29%29%29&g0.tab=0)
-//   - [Concurrent Calls](http://localhost:9090/graph?g0.expr=%23+Concurrent+calls+to+the+%60randomErrorHandler%60+function%0A%0Asum+by+%28function%2C+module%29+function_calls_concurrent%7Bfunction%3D%22randomErrorHandler%22%7D&g0.tab=0)
+//   - [Request Rate]
+//   - [Error Ratio]
+//   - [Latency (95th and 99th percentiles)]
+//   - [Concurrent Calls]
 //
 // Or, dig into the metrics of *functions called by* `randomErrorHandler`
+//   - [Request Rate Callee]
+//   - [Error Ratio Callee]
 //
-//   - [Request Rate](http://localhost:9090/graph?g0.expr=%23+Rate+of+function+calls+emanating+from+%60randomErrorHandler%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_counter%7Bcaller%3D%22randomErrorHandler%22%7D%5B5m%5D%29%29&g0.tab=0)
+//	autometrics:doc-end DO NOT EDIT HERE AND LINE BELOW
 //
-//   - [Error Ratio](http://localhost:9090/graph?g0.expr=%23+Percentage+of+function+emanating+from+%60randomErrorHandler%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_counter%7Bcaller%3D%22randomErrorHandler%22%2Cresult%3D%22error%22%7D%5B5m%5D%29%29&g0.tab=0)
-//
-//     autometrics:doc-end DO NOT EDIT
+// [Request Rate]: http://localhost:9090/graph?g0.expr=%23+Rate+of+calls+to+the+%60randomErrorHandler%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_count%7Bfunction%3D%22randomErrorHandler%22%7D%5B5m%5D%29%29&g0.tab=0
+// [Error Ratio]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+calls+to+the+%60randomErrorHandler%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_count%7Bfunction%3D%22randomErrorHandler%22%2Cresult%3D%22error%22%7D%5B5m%5D%29%29&g0.tab=0
+// [Latency (95th and 99th percentiles)]: http://localhost:9090/graph?g0.expr=%23+95th+and+99th+percentile+latencies+%28in+seconds%29+for+the+%60randomErrorHandler%60+function%0A%0Ahistogram_quantile%280.99%2C+sum+by+%28le%2C+function%2C+module%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22randomErrorHandler%22%7D%5B5m%5D%29%29%29+or+histogram_quantile%280.95%2C+sum+by+%28le%2C+function%2C+module%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22randomErrorHandler%22%7D%5B5m%5D%29%29%29&g0.tab=0
+// [Concurrent Calls]: http://localhost:9090/graph?g0.expr=%23+Concurrent+calls+to+the+%60randomErrorHandler%60+function%0A%0Asum+by+%28function%2C+module%29+function_calls_concurrent%7Bfunction%3D%22randomErrorHandler%22%7D&g0.tab=0
+// [Request Rate Callee]: http://localhost:9090/graph?g0.expr=%23+Rate+of+function+calls+emanating+from+%60randomErrorHandler%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_count%7Bcaller%3D%22main.randomErrorHandler%22%7D%5B5m%5D%29%29&g0.tab=0
+// [Error Ratio Callee]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+function+emanating+from+%60randomErrorHandler%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_count%7Bcaller%3D%22main.randomErrorHandler%22%2Cresult%3D%22error%22%7D%5B5m%5D%29%29&g0.tab=0
 //
 //autometrics:doc
 func randomErrorHandler(w http.ResponseWriter, _ *http.Request) (err error) {
-        defer autometrics.Instrument(autometrics.PreInstrument(), &err) //autometrics:defer-statement
+	defer autometrics.Instrument(autometrics.PreInstrument(), &err) //autometrics:defer-statement
 	isErr := rand.Intn(2) == 0
 
 	if isErr {

--- a/examples/web/cmd/main.go.bak
+++ b/examples/web/cmd/main.go.bak
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/autometrics-dev/autometrics-go/pkg/autometrics"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -20,14 +19,11 @@ import (
 func main() {
 	rand.Seed(time.Now().UnixNano())
 
-	reg := prometheus.NewRegistry()
-	autometrics.Init(reg)
+	autometrics.Init(nil)
 
 	http.HandleFunc("/", errorable(indexHandler))
 	http.HandleFunc("/random-error", errorable(randomErrorHandler))
-	// TODO: add a "/metrics" handler
-	// Expose /metrics HTTP endpoint using the created custom registry.
-	http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{Registry: reg}))
+	http.Handle("/metrics", promhttp.Handler())
 
 	log.Println("binding on http://localhost:62086")
 	log.Fatal(http.ListenAndServe(":62086", nil))
@@ -39,6 +35,7 @@ func main() {
 //
 //autometrics:doc
 func indexHandler(w http.ResponseWriter, _ *http.Request) (err error) {
+	defer autometrics.Instrument(autometrics.PreInstrument(), &err) //autometrics:defer-statement
 	_, err = fmt.Fprintf(w, "Hello, World!\n")
 	return
 }
@@ -51,6 +48,7 @@ var handlerError = errors.New("failed to handle request")
 //
 //autometrics:doc
 func randomErrorHandler(w http.ResponseWriter, _ *http.Request) (err error) {
+	defer autometrics.Instrument(autometrics.PreInstrument(), &err) //autometrics:defer-statement
 	isErr := rand.Intn(2) == 0
 
 	if isErr {

--- a/go.work
+++ b/go.work
@@ -1,0 +1,6 @@
+go 1.20
+
+use (
+	.
+	./examples/web
+)

--- a/internal/doc/generate_test.go
+++ b/internal/doc/generate_test.go
@@ -29,24 +29,31 @@ func main() {
 		"// This comment is associated with the main function.\n" +
 		"//\n" +
 		"//\n" +
-		"//   autometrics:doc-start DO NOT EDIT\n" +
+		"//   autometrics:doc-start DO NOT EDIT HERE AND LINE ABOVE\n" +
 		"//\n" +
 		"// # Autometrics\n" +
 		"//\n" +
 		"// ## Prometheus\n" +
 		"//\n" +
 		"// View the live metrics for the `main` function:\n" +
-		"//   - [Request Rate](http://localhost:9090/graph?g0.expr=%23+Rate+of+calls+to+the+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_counter%7Bfunction%3D%22main%22%7D%5B5m%5D%29%29&g0.tab=0)\n" +
-		"//   - [Error Ratio](http://localhost:9090/graph?g0.expr=%23+Percentage+of+calls+to+the+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_counter%7Bfunction%3D%22main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29%29&g0.tab=0)\n" +
-		"//   - [Latency (95th and 99th percentiles)](http://localhost:9090/graph?g0.expr=%23+95th+and+99th+percentile+latencies+%28in+seconds%29+for+the+%60main%60+function%0A%0Ahistogram_quantile%280.99%2C+sum+by+%28le%2C+function%2C+module%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22main%22%7D%5B5m%5D%29%29%29+or+histogram_quantile%280.95%2C+sum+by+%28le%2C+function%2C+module%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22main%22%7D%5B5m%5D%29%29%29&g0.tab=0)\n" +
-		"//   - [Concurrent Calls](http://localhost:9090/graph?g0.expr=%23+Concurrent+calls+to+the+%60main%60+function%0A%0Asum+by+%28function%2C+module%29+function_calls_concurrent%7Bfunction%3D%22main%22%7D&g0.tab=0)\n" +
+		"//   - [Request Rate]\n" +
+		"//   - [Error Ratio]\n" +
+		"//   - [Latency (95th and 99th percentiles)]\n" +
+		"//   - [Concurrent Calls]\n" +
 		"//\n" +
 		"// Or, dig into the metrics of *functions called by* `main`\n" +
-		"//   - [Request Rate](http://localhost:9090/graph?g0.expr=%23+Rate+of+function+calls+emanating+from+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_counter%7Bcaller%3D%22main.main%22%7D%5B5m%5D%29%29&g0.tab=0)\n" +
-		"//   - [Error Ratio](http://localhost:9090/graph?g0.expr=%23+Percentage+of+function+emanating+from+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_counter%7Bcaller%3D%22main.main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29%29&g0.tab=0)\n" +
+		"//   - [Request Rate Callee]\n" +
+		"//   - [Error Ratio Callee]\n" +
+		"//\n" +
+		"// [Request Rate]: http://localhost:9090/graph?g0.expr=%23+Rate+of+calls+to+the+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_count%7Bfunction%3D%22main%22%7D%5B5m%5D%29%29&g0.tab=0\n" +
+		"// [Error Ratio]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+calls+to+the+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_count%7Bfunction%3D%22main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29%29&g0.tab=0\n" +
+		"// [Latency (95th and 99th percentiles)]: http://localhost:9090/graph?g0.expr=%23+95th+and+99th+percentile+latencies+%28in+seconds%29+for+the+%60main%60+function%0A%0Ahistogram_quantile%280.99%2C+sum+by+%28le%2C+function%2C+module%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22main%22%7D%5B5m%5D%29%29%29+or+histogram_quantile%280.95%2C+sum+by+%28le%2C+function%2C+module%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22main%22%7D%5B5m%5D%29%29%29&g0.tab=0\n" +
+		"// [Concurrent Calls]: http://localhost:9090/graph?g0.expr=%23+Concurrent+calls+to+the+%60main%60+function%0A%0Asum+by+%28function%2C+module%29+function_calls_concurrent%7Bfunction%3D%22main%22%7D&g0.tab=0\n" +
+		"// [Request Rate Callee]: http://localhost:9090/graph?g0.expr=%23+Rate+of+function+calls+emanating+from+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_count%7Bcaller%3D%22main.main%22%7D%5B5m%5D%29%29&g0.tab=0\n" +
+		"// [Error Ratio Callee]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+function+emanating+from+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_count%7Bcaller%3D%22main.main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29%29&g0.tab=0\n" +
 		"//\n" +
 		"//\n" +
-		"//   autometrics:doc-end DO NOT EDIT\n" +
+		"//   autometrics:doc-end DO NOT EDIT HERE AND LINE BELOW\n" +
 		"//\n" +
 		"//autometrics:doc\n" +
 		"func main() {\n" +
@@ -87,26 +94,31 @@ func main() {
 		"\n" +
 		"// This comment is associated with the main function.\n" +
 		"//\n" +
-		"//\n" +
-		"//\n" +
-		"//   autometrics:doc-start DO NOT EDIT\n" +
+		"//   autometrics:doc-start DO NOT EDIT HERE AND LINE ABOVE\n" +
 		"//\n" +
 		"// # Autometrics\n" +
 		"//\n" +
 		"// ## Prometheus\n" +
 		"//\n" +
 		"// View the live metrics for the `main` function:\n" +
-		"//   - [Request Rate](http://localhost:9090/graph?g0.expr=%23+Rate+of+calls+to+the+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_counter%7Bfunction%3D%22main%22%7D%5B5m%5D%29%29&g0.tab=0)\n" +
-		"//   - [Error Ratio](http://localhost:9090/graph?g0.expr=%23+Percentage+of+calls+to+the+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_counter%7Bfunction%3D%22main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29%29&g0.tab=0)\n" +
-		"//   - [Latency (95th and 99th percentiles)](http://localhost:9090/graph?g0.expr=%23+95th+and+99th+percentile+latencies+%28in+seconds%29+for+the+%60main%60+function%0A%0Ahistogram_quantile%280.99%2C+sum+by+%28le%2C+function%2C+module%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22main%22%7D%5B5m%5D%29%29%29+or+histogram_quantile%280.95%2C+sum+by+%28le%2C+function%2C+module%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22main%22%7D%5B5m%5D%29%29%29&g0.tab=0)\n" +
-		"//   - [Concurrent Calls](http://localhost:9090/graph?g0.expr=%23+Concurrent+calls+to+the+%60main%60+function%0A%0Asum+by+%28function%2C+module%29+function_calls_concurrent%7Bfunction%3D%22main%22%7D&g0.tab=0)\n" +
+		"//   - [Request Rate]\n" +
+		"//   - [Error Ratio]\n" +
+		"//   - [Latency (95th and 99th percentiles)]\n" +
+		"//   - [Concurrent Calls]\n" +
 		"//\n" +
 		"// Or, dig into the metrics of *functions called by* `main`\n" +
-		"//   - [Request Rate](http://localhost:9090/graph?g0.expr=%23+Rate+of+function+calls+emanating+from+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_counter%7Bcaller%3D%22main.main%22%7D%5B5m%5D%29%29&g0.tab=0)\n" +
-		"//   - [Error Ratio](http://localhost:9090/graph?g0.expr=%23+Percentage+of+function+emanating+from+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_counter%7Bcaller%3D%22main.main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29%29&g0.tab=0)\n" +
+		"//   - [Request Rate Callee]\n" +
+		"//   - [Error Ratio Callee]\n" +
+		"//\n" +
+		"// [Request Rate]: http://localhost:9090/graph?g0.expr=%23+Rate+of+calls+to+the+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_count%7Bfunction%3D%22main%22%7D%5B5m%5D%29%29&g0.tab=0\n" +
+		"// [Error Ratio]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+calls+to+the+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_count%7Bfunction%3D%22main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29%29&g0.tab=0\n" +
+		"// [Latency (95th and 99th percentiles)]: http://localhost:9090/graph?g0.expr=%23+95th+and+99th+percentile+latencies+%28in+seconds%29+for+the+%60main%60+function%0A%0Ahistogram_quantile%280.99%2C+sum+by+%28le%2C+function%2C+module%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22main%22%7D%5B5m%5D%29%29%29+or+histogram_quantile%280.95%2C+sum+by+%28le%2C+function%2C+module%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22main%22%7D%5B5m%5D%29%29%29&g0.tab=0\n" +
+		"// [Concurrent Calls]: http://localhost:9090/graph?g0.expr=%23+Concurrent+calls+to+the+%60main%60+function%0A%0Asum+by+%28function%2C+module%29+function_calls_concurrent%7Bfunction%3D%22main%22%7D&g0.tab=0\n" +
+		"// [Request Rate Callee]: http://localhost:9090/graph?g0.expr=%23+Rate+of+function+calls+emanating+from+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_count%7Bcaller%3D%22main.main%22%7D%5B5m%5D%29%29&g0.tab=0\n" +
+		"// [Error Ratio Callee]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+function+emanating+from+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%29+%28rate%28function_calls_count%7Bcaller%3D%22main.main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29%29&g0.tab=0\n" +
 		"//\n" +
 		"//\n" +
-		"//   autometrics:doc-end DO NOT EDIT\n" +
+		"//   autometrics:doc-end DO NOT EDIT HERE AND LINE BELOW\n" +
 		"//\n" +
 		"//autometrics:doc\n" +
 		"func main() {\n" +

--- a/internal/doc/prometheus.go
+++ b/internal/doc/prometheus.go
@@ -10,7 +10,7 @@ const prometheusInstanceUrl = "http://localhost:9090/"
 
 // TODO: Use globals from somewhere else in the lib
 const (
-	callCounterMetricName     = "function_calls_counter"
+	callCounterMetricName     = "function_calls_count"
 	callDurationMetricName    = "function_calls_duration_bucket"
 	concurrentCallsMetricName = "function_calls_concurrent"
 )
@@ -53,6 +53,7 @@ func errorRatioQuery(counterName, labelKey, labelValue string) string {
 
 func latencyQuery(bucketName, labelKey, labelValue string) string {
 	latency := fmt.Sprintf("sum by (le, function, module) (rate(%s{%s=\"%s\"}[5m]))", bucketName, labelKey, labelValue)
+
 	return fmt.Sprintf("histogram_quantile(0.99, %s) or histogram_quantile(0.95, %s)", latency, latency)
 }
 
@@ -79,14 +80,25 @@ func (p Prometheus) GenerateAutometricsComment(funcName, moduleName string) []st
 		"// ## Prometheus",
 		"//",
 		fmt.Sprintf("// View the live metrics for the `%s` function:", funcName),
-		fmt.Sprintf("//   - [Request Rate](%s)", requestRateUrl.String()),
-		fmt.Sprintf("//   - [Error Ratio](%s)", errorRatioUrl.String()),
-		fmt.Sprintf("//   - [Latency (95th and 99th percentiles)](%s)", latencyUrl.String()),
-		fmt.Sprintf("//   - [Concurrent Calls](%s)", concurrentCallsUrl.String()),
+		"//   - [Request Rate]",
+		"//   - [Error Ratio]",
+		"//   - [Latency (95th and 99th percentiles)]",
+		"//   - [Concurrent Calls]",
 		"//",
 		fmt.Sprintf("// Or, dig into the metrics of *functions called by* `%s`", funcName),
-		fmt.Sprintf("//   - [Request Rate](%s)", calleeRequestRateUrl.String()),
-		fmt.Sprintf("//   - [Error Ratio](%s)", calleeErrorRatioUrl.String()),
+		"//   - [Request Rate Callee]",
+		"//   - [Error Ratio Callee]",
+		"//",
+		fmt.Sprintf("// [Request Rate]: %s", requestRateUrl.String()),
+		fmt.Sprintf("// [Error Ratio]: %s", errorRatioUrl.String()),
+		fmt.Sprintf("// [Latency (95th and 99th percentiles)]: %s", latencyUrl.String()),
+		fmt.Sprintf("// [Concurrent Calls]: %s", concurrentCallsUrl.String()),
+		fmt.Sprintf("// [Request Rate Callee]: %s", calleeRequestRateUrl.String()),
+		fmt.Sprintf("// [Error Ratio Callee]: %s", calleeErrorRatioUrl.String()),
 		"//",
 	}
+}
+
+func (p Prometheus) GeneratedLinks() []string {
+	return []string {"Request Rate", "Error Ratio", "Latency (95th and 99th percentiles)" , "Concurrent Calls", "Request Rate Callee", "Error Ratio Callee"}
 }


### PR DESCRIPTION
Links only work with "footer" syntax in go documentation.

That means the links get auto-formatted out of the range of "generated comments" delimited by cookies.

To counteract this effect, the Generator interface has an extra method that declares all the links it generated to allow for link cleanup even outside of cookies