### PR TITLE
Make Context absorb startTime and CallerInfo

### DIFF
--- a/examples/web/cmd/main.go
+++ b/examples/web/cmd/main.go
@@ -60,11 +60,7 @@ func main() {
 //
 //autometrics:doc
 func indexHandler(w http.ResponseWriter, _ *http.Request) error {
-	defer autometrics.Instrument(autometrics.Context{
-		TrackConcurrentCalls: true,
-		TrackCallerName:      true,
-		AlertConf:            nil,
-	}, autometrics.PreInstrument(autometrics.Context{
+	defer autometrics.Instrument(autometrics.PreInstrument(&autometrics.Context{
 		TrackConcurrentCalls: true,
 		TrackCallerName:      true,
 		AlertConf:            nil,
@@ -109,11 +105,7 @@ var handlerError = errors.New("failed to handle request")
 //
 //autometrics:doc --slo "API" --success-target 90
 func randomErrorHandler(w http.ResponseWriter, _ *http.Request) (err error) {
-	defer autometrics.Instrument(autometrics.Context{
-		TrackConcurrentCalls: true,
-		TrackCallerName:      true,
-		AlertConf:            &autometrics.AlertConfiguration{ServiceName: "API", Latency: nil, Success: &autometrics.SuccessSlo{Objective: 90}},
-	}, autometrics.PreInstrument(autometrics.Context{
+	defer autometrics.Instrument(autometrics.PreInstrument(&autometrics.Context{
 		TrackConcurrentCalls: true,
 		TrackCallerName:      true,
 		AlertConf:            &autometrics.AlertConfiguration{ServiceName: "API", Latency: nil, Success: &autometrics.SuccessSlo{Objective: 90}},

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"go/token"
 
 	"github.com/google/shlex"
 
@@ -266,19 +267,18 @@ func buildAutometricsDeferStatement(ctx ctx.AutometricsGeneratorContext, secondV
 	if err != nil {
 		return dst.DeferStmt{}, fmt.Errorf("could not generate the runtime context value: %w", err)
 	}
-	instrumentArg, err := buildAutometricsContextNode(ctx)
-	if err != nil {
-		return dst.DeferStmt{}, fmt.Errorf("could not generate the runtime context value: %w", err)
-	}
 	statement := dst.DeferStmt{
 		Call: &dst.CallExpr{
 			Fun: dst.NewIdent("autometrics.Instrument"),
 			Args: []dst.Expr{
-				instrumentArg,
 				&dst.CallExpr{
 					Fun: dst.NewIdent("autometrics.PreInstrument"),
 					Args: []dst.Expr{
-						preInstrumentArg,
+						&dst.UnaryExpr{
+							Op:   token.AND,
+							X:    preInstrumentArg,
+							Decs: dst.UnaryExprDecorations{},
+						},
 					},
 				},
 				dst.NewIdent(secondVar),

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -62,11 +62,7 @@ func main() {
 		"//\n" +
 		"//autometrics:doc --slo \"Service Test\" --success-target 99\n" +
 		"func main() {\n" +
-		"\tdefer autometrics.Instrument(autometrics.Context{\n" +
-		"\t\tTrackConcurrentCalls: true,\n" +
-		"\t\tTrackCallerName:      true,\n" +
-		"\t\tAlertConf:            &autometrics.AlertConfiguration{ServiceName: \"Service Test\", Latency: nil, Success: &autometrics.SuccessSlo{Objective: 99}},\n" +
-		"\t}, autometrics.PreInstrument(autometrics.Context{\n" +
+		"\tdefer autometrics.Instrument(autometrics.PreInstrument(&autometrics.Context{\n" +
 		"\t\tTrackConcurrentCalls: true,\n" +
 		"\t\tTrackCallerName:      true,\n" +
 		"\t\tAlertConf:            &autometrics.AlertConfiguration{ServiceName: \"Service Test\", Latency: nil, Success: &autometrics.SuccessSlo{Objective: 99}},\n" +
@@ -137,11 +133,7 @@ func main() {
 		"//\n" +
 		"//autometrics:doc --slo \"API\" --latency-target 99.9 --latency-ms 0.5\n" +
 		"func main() {\n" +
-		"\tdefer autometrics.Instrument(autometrics.Context{\n" +
-		"\t\tTrackConcurrentCalls: true,\n" +
-		"\t\tTrackCallerName:      true,\n" +
-		"\t\tAlertConf:            &autometrics.AlertConfiguration{ServiceName: \"API\", Latency: &autometrics.LatencySlo{Target: 500000 * time.Nanosecond, Objective: 99.9}, Success: nil},\n" +
-		"\t}, autometrics.PreInstrument(autometrics.Context{\n" +
+		"\tdefer autometrics.Instrument(autometrics.PreInstrument(&autometrics.Context{\n" +
 		"\t\tTrackConcurrentCalls: true,\n" +
 		"\t\tTrackCallerName:      true,\n" +
 		"\t\tAlertConf:            &autometrics.AlertConfiguration{ServiceName: \"API\", Latency: &autometrics.LatencySlo{Target: 500000 * time.Nanosecond, Objective: 99.9}, Success: nil},\n" +

--- a/pkg/autometrics/main.go
+++ b/pkg/autometrics/main.go
@@ -74,6 +74,26 @@ type Context struct {
 	TrackCallerName bool
 	// AlertConf is an optional configuration to add alerting capabilities to the metrics.
 	AlertConf *AlertConfiguration
+	// startTime is the start time of a single function execution.
+	// Only autometrics.Instrument should read this value.
+	// Only autometrics.PreInstrument should write this value.
+	startTime time.Time
+	// callInfo contains all the relevant data for caller information.
+	// Only autometrics.Instrument should read this value.
+	// Only autometrics.PreInstrument should write/read this value.
+	callInfo CallInfo
+}
+
+// CallInfo holds the information about the current function call and its parent names.
+type CallInfo struct {
+	// FuncName is name of the function being tracked.
+	FuncName string
+	// ModuleName is name of the module of the function being tracked.
+	ModuleName string
+	// ParentFuncName is name of the caller of the function being tracked.
+	ParentFuncName string
+	// ParentModuleName is name of the module of the caller of the function being tracked.
+	ParentModuleName string
 }
 
 func NewContext() Context {


### PR DESCRIPTION
Following external feedback we had on the library, it got to our attention that the context that's been created to have SLOs and alerts working should really be used for the `callerInfo` data and the start time of a function execution.

This reduces the content of generated code and allows to reduce stack inspection