### PR TITLE
Add release workflow for generator asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
-name: Release
+name: Build and Release Binaries
 
-on:
-  push:
-    tags:
-      - v**
+on: [push]
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -12,7 +11,6 @@ jobs:
     strategy:
       matrix:
         build: [linux_amd64, windows_amd64, darwin_amd64, darwin_arm64]
-        compress: [tar]
         include:
           - build: linux_amd64
             goos: linux
@@ -22,7 +20,6 @@ jobs:
             goos: windows
             goarch: amd64
             ext: '.exe'
-            compress: zip
           - build: darwin_amd64
             goos: darwin
             goarch: amd64
@@ -43,34 +40,20 @@ jobs:
           GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build cmd/autometrics/main.go
           mv main${{ matrix.ext }} autometrics${{ matrix.ext }}
 
-      - name: Pack (Tar)
-        if: matrix.compress == 'tar'
-        run: |
-          tar -c -f autometrics-${{ matrix.build }}.tar.gz -v -z autometrics${{ matrix.ext }}
-      - name: Upload (Tar)
-        if: matrix.compress == 'tar'
-        uses: actions/upload-artifact@v3
-        with:
-          name: autometrics ${{ matrix.build }}
-          path: autometrics-${{ matrix.build }}.tar.gz
-          if-no-files-found: error
-          retention-days: 1
-
       - name: Pack (Zip)
-        if: matrix.compress == 'zip'
         run: |
           zip autometrics-${{ matrix.build }}.zip -v -z autometrics${{ matrix.ext }}
       - name: Upload (Zip)
-        if: matrix.compress == 'zip'
         uses: actions/upload-artifact@v3
         with:
           name: autometrics ${{ matrix.build }}
           path: autometrics-${{ matrix.build }}.zip
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 7
 
   add_assets:
     name: 'Add Assets'
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     needs: [build]
     steps:
@@ -94,7 +77,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            *.tar.gz
             *.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v**
+
+jobs:
+  go-generator:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.20"
+          check-latest: true
+          cache: true
+      - name: Linux x86
+        run: |
+          GOOS=linux GOARCH=amd64 go build cmd/autometrics/main.go
+          tar -c -f autometrics-linux_amd64.tar.gz -z autometrics
+      - name: Windows x86
+        run: |
+          GOOS=windows GOARCH=amd64 go build cmd/autometrics/main.go
+          zip autometrics-windows_amd64.zip -z autometrics.exe
+      - name: MacOS x86
+        run: |
+          GOOS=darwin GOARCH=amd64 go build cmd/autometrics/main.go
+          tar -c -f autometrics-darwin_amd64.tar.gz -z autometrics
+      - name: MacOS ARM
+        run: |
+          GOOS=darwin GOARCH=arm64 go build cmd/autometrics/main.go
+          tar -c -f autometrics-darwin_arm64.tar.gz -z autometrics
+      - name: Release with Notes
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            *.tar.gz
+            *.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,19 +19,27 @@ jobs:
       - name: Linux x86
         run: |
           GOOS=linux GOARCH=amd64 go build cmd/autometrics/main.go
-          tar -c -f autometrics-linux_amd64.tar.gz -z autometrics
+          mv main autometrics
+          tar -c -f autometrics-linux_amd64.tar.gz -v -z autometrics
+          rm -v autometrics
       - name: Windows x86
         run: |
           GOOS=windows GOARCH=amd64 go build cmd/autometrics/main.go
-          zip autometrics-windows_amd64.zip -z autometrics.exe
+          mv main.exe autometrics.exe
+          zip autometrics-windows_amd64.zip -v -z autometrics.exe
+          rm -v autometrics.exe
       - name: MacOS x86
         run: |
           GOOS=darwin GOARCH=amd64 go build cmd/autometrics/main.go
-          tar -c -f autometrics-darwin_amd64.tar.gz -z autometrics
+          mv main autometrics
+          tar -c -f autometrics-darwin_amd64.tar.gz -v -z autometrics
+          rm -v autometrics
       - name: MacOS ARM
         run: |
           GOOS=darwin GOARCH=arm64 go build cmd/autometrics/main.go
-          tar -c -f autometrics-darwin_arm64.tar.gz -z autometrics
+          mv main autometrics
+          tar -c -f autometrics-darwin_arm64.tar.gz -v -z autometrics
+          rm -v autometrics
       - name: Release with Notes
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,40 +6,90 @@ on:
       - v**
 
 jobs:
-  go-generator:
+  build:
+    name: 'Build Assets'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        build: [linux_amd64, windows_amd64, darwin_amd64, darwin_arm64]
+        compress: [tar]
+        include:
+          - build: linux_amd64
+            goos: linux
+            goarch: amd64
+            ext: ''
+          - build: windows_amd64
+            goos: windows
+            goarch: amd64
+            ext: '.exe'
+            compress: zip
+          - build: darwin_amd64
+            goos: darwin
+            goarch: amd64
+            ext: ''
+          - build: darwin_arm64
+            goos: darwin
+            goarch: arm64
+            ext: ''
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: "1.20"
           check-latest: true
-          cache: true
-      - name: Linux x86
+      - name: Build
         run: |
-          GOOS=linux GOARCH=amd64 go build cmd/autometrics/main.go
-          mv main autometrics
-          tar -c -f autometrics-linux_amd64.tar.gz -v -z autometrics
-          rm -v autometrics
-      - name: Windows x86
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build cmd/autometrics/main.go
+          mv main${{ matrix.ext }} autometrics${{ matrix.ext }}
+
+      - name: Pack (Tar)
+        if: matrix.compress == 'tar'
         run: |
-          GOOS=windows GOARCH=amd64 go build cmd/autometrics/main.go
-          mv main.exe autometrics.exe
-          zip autometrics-windows_amd64.zip -v -z autometrics.exe
-          rm -v autometrics.exe
-      - name: MacOS x86
+          tar -c -f autometrics-${{ matrix.build }}.tar.gz -v -z autometrics${{ matrix.ext }}
+      - name: Upload (Tar)
+        if: matrix.compress == 'tar'
+        uses: actions/upload-artifact@v3
+        with:
+          name: autometrics ${{ matrix.build }}
+          path: autometrics-${{ matrix.build }}.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Pack (Zip)
+        if: matrix.compress == 'zip'
         run: |
-          GOOS=darwin GOARCH=amd64 go build cmd/autometrics/main.go
-          mv main autometrics
-          tar -c -f autometrics-darwin_amd64.tar.gz -v -z autometrics
-          rm -v autometrics
-      - name: MacOS ARM
-        run: |
-          GOOS=darwin GOARCH=arm64 go build cmd/autometrics/main.go
-          mv main autometrics
-          tar -c -f autometrics-darwin_arm64.tar.gz -v -z autometrics
-          rm -v autometrics
+          zip autometrics-${{ matrix.build }}.zip -v -z autometrics${{ matrix.ext }}
+      - name: Upload (Zip)
+        if: matrix.compress == 'zip'
+        uses: actions/upload-artifact@v3
+        with:
+          name: autometrics ${{ matrix.build }}
+          path: autometrics-${{ matrix.build }}.zip
+          if-no-files-found: error
+          retention-days: 1
+
+  add_assets:
+    name: 'Add Assets'
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Fetch Linux (AMD64) build
+        uses: actions/download-artifact@v3
+        with:
+          name: autometrics linux_amd64
+      - name: Fetch Windows (AMD64) build
+        uses: actions/download-artifact@v3
+        with:
+          name: autometrics windows_amd64
+      - name: Fetch Darwin (AMD64) build
+        uses: actions/download-artifact@v3
+        with:
+          name: autometrics darwin_amd64
+      - name: Fetch Darwin (ARM64) build
+        uses: actions/download-artifact@v3
+        with:
+          name: autometrics darwin_arm64
       - name: Release with Notes
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
This workflow builds the go generator for multiple releases on version
tags, and then adds the assets to the release on Github. This should
ease the recuperation ef the generator.

Closes: #30
