### PR TITLE
Add support for ignoring/deleting generated links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,18 @@ versioning](https://go.dev/doc/modules/version-numbers).
 
 - Changelog to summarize changes in a single place
 - Pull Request template for the repository
+- `--no-doc` argument to the generator to prevent the generator from
+  generating documentation links in the doc comments in the given file
+- `--no-doc` argument to the `autometrics:inst` directive to prevent
+  the generator from generating links on specific functions
 
 ### Changed
 
+- The `//autometrics:doc` directive has been renamed `//autometrics:inst`
+
 ### Deprecated
+
+- The `//autometrics:doc` directive has been renamed `//autometrics:inst`
 
 ### Removed
 

--- a/cmd/autometrics/main.go
+++ b/cmd/autometrics/main.go
@@ -23,6 +23,7 @@ type args struct {
 	PrometheusUrl        string `arg:"--prom_url,env:AM_PROMETHEUS_URL" placeholder:"PROMETHEUS_URL" default:"http://localhost:9090" help:"Base URL of the Prometheus instance to generate links to."`
 	UseOtel              bool   `arg:"--otel" default:"false" help:"Use OpenTelemetry client library to instrument code instead of default Prometheus."`
 	AllowCustomLatencies bool   `arg:"--custom-latency" default:"false" help:"Allow non-default latencies to be used in latency-based SLOs."`
+	DisableDocGeneration bool   `arg:"--no-doc,env:AM_NO_DOCGEN" default:"false" help:"Disable documentation links generation for all instrumented functions. Has the same effect as --no-doc in the //autometrics:inst directive."`
 }
 
 func (args) Version() string {
@@ -63,7 +64,12 @@ func main() {
 		implementation = autometrics.OTEL
 	}
 
-	ctx, err := internal.NewGeneratorContext(implementation, args.PrometheusUrl, args.AllowCustomLatencies)
+	ctx, err := internal.NewGeneratorContext(
+		implementation,
+		args.PrometheusUrl,
+		args.AllowCustomLatencies,
+		args.DisableDocGeneration,
+	)
 	if err != nil {
 		log.Fatalf("error initialising autometrics context: %s", err)
 	}

--- a/internal/autometrics/ctx.go
+++ b/internal/autometrics/ctx.go
@@ -7,12 +7,27 @@ import (
 	"github.com/autometrics-dev/autometrics-go/pkg/autometrics"
 )
 
+// GeneratorContext contains the complete command-line and environment context from the generator invocation.
+//
+// This context contains all the information necessary to properly process the `autometrics` directives over
+// each instrumented function in the file.
 type GeneratorContext struct {
-	RuntimeCtx             autometrics.Context
-	FuncCtx                GeneratorFunctionContext
-	Implementation         autometrics.Implementation
+	// RuntimeCtx holds the runtime context to build from in the generated code.
+	RuntimeCtx autometrics.Context
+	// FuncCtx holds the function specific information for the detected autometrics directive.
+	//
+	// Notably, it contains all the data relative to the parsing of the arguments in the directive.
+	FuncCtx GeneratorFunctionContext
+	// Implementation is the metrics library we expect to use in the instrumented code.
+	Implementation autometrics.Implementation
+	// DocumentationGenerator is the generator to use to generate comments.
 	DocumentationGenerator AutometricsLinkCommentGenerator
-	AllowCustomLatencies   bool
+	// Allow the autometrics directive to have latency targets outside the default buckets.
+	AllowCustomLatencies bool
+	// Flag to disable/remove the documentation links when calling the generator.
+	//
+	// This can be set in the command for the generator or through the environment.
+	DisableDocGeneration bool
 }
 
 type GeneratorFunctionContext struct {
@@ -20,6 +35,7 @@ type GeneratorFunctionContext struct {
 	FunctionName   string
 	ModuleName     string
 	ImplImportName string
+	DisableDocGeneration bool
 }
 
 func (c *GeneratorContext) ResetFuncCtx() {
@@ -32,10 +48,11 @@ func (c *GeneratorContext) SetCommentIdx(i int) {
 	c.FuncCtx.CommentIndex = i
 }
 
-func NewGeneratorContext(implementation autometrics.Implementation, prometheusUrl string, allowCustomLatencies bool) (GeneratorContext, error) {
+func NewGeneratorContext(implementation autometrics.Implementation, prometheusUrl string, allowCustomLatencies, disableDocGeneration bool) (GeneratorContext, error) {
 	ctx := GeneratorContext{
 		Implementation:       implementation,
 		AllowCustomLatencies: allowCustomLatencies,
+		DisableDocGeneration: disableDocGeneration,
 		RuntimeCtx:           autometrics.NewContext(),
 		FuncCtx:              GeneratorFunctionContext{},
 	}


### PR DESCRIPTION
The generator takes an extra argument, through command-line or
environment variable, that allows to opt-out of documentation
generation. There is also the possibility to opt-in this deactivation on
a per-function basis, using the `--no-doc` argument on the directive.

This also changes the name of the directive, from `autometrics:doc` to
`autometrics:inst`, as now the directive doesn't always add
documentation to the functions it instruments. For backwards
compatibility, the `doc` attribute is still accepted, and will be
removed in a later version.

Closes #38
