### PR TITLE
Change function calls count to use a monotonic counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ versioning](https://go.dev/doc/modules/version-numbers).
 ### Changed
 
 - The `//autometrics:doc` directive has been renamed `//autometrics:inst`
+- The type of counter for `function.calls.count` metric has been changed to
+  a monotonic Int64 counter
 
 ### Deprecated
 

--- a/pkg/autometrics/otel/otel.go
+++ b/pkg/autometrics/otel/otel.go
@@ -116,10 +116,6 @@ func Init(meterName string, histogramBuckets []float64, buildInformation BuildIn
 	)
 	meter := provider.Meter(completeMeterName(meterName))
 
-	// We are using an UpDown counter instead of the natural Counter because with a monotonic counter
-	// there is no way to remove the '_total' suffix from the exported metric name. This suffix
-	// makes the exported metrics incompatible with the autometrics.rules.yml file.
-	// Ref: https://github.com/open-telemetry/opentelemetry-go/blob/6b7e207953ce0a13d38da628a6aa48ad56058d2a/exporters/prometheus/exporter.go#L212-L215
 	functionCallsCount, err = meter.Int64Counter(FunctionCallsCountName, instrument.WithDescription("The number of times the function has been called"))
 	if err != nil {
 		return fmt.Errorf("error initializing %v metric: %w", FunctionCallsCountName, err)

--- a/pkg/autometrics/otel/otel.go
+++ b/pkg/autometrics/otel/otel.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	functionCallsCount      instrument.Int64UpDownCounter
+	functionCallsCount      instrument.Int64Counter
 	functionCallsDuration   instrument.Float64Histogram
 	functionCallsConcurrent instrument.Int64UpDownCounter
 	buildInfo               instrument.Int64UpDownCounter
@@ -120,7 +120,7 @@ func Init(meterName string, histogramBuckets []float64, buildInformation BuildIn
 	// there is no way to remove the '_total' suffix from the exported metric name. This suffix
 	// makes the exported metrics incompatible with the autometrics.rules.yml file.
 	// Ref: https://github.com/open-telemetry/opentelemetry-go/blob/6b7e207953ce0a13d38da628a6aa48ad56058d2a/exporters/prometheus/exporter.go#L212-L215
-	functionCallsCount, err = meter.Int64UpDownCounter(FunctionCallsCountName, instrument.WithDescription("The number of times the function has been called"))
+	functionCallsCount, err = meter.Int64Counter(FunctionCallsCountName, instrument.WithDescription("The number of times the function has been called"))
 	if err != nil {
 		return fmt.Errorf("error initializing %v metric: %w", FunctionCallsCountName, err)
 	}


### PR DESCRIPTION
# Description

- Update autometrics-shared submodule
- fix(otel): change function calls counter type

Fixes issue #37

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] The CHANGELOG is updated.
- [x] The open-telemetry example in repository works fine:
  + the docker compose file is valid
  + the application compiles and run
  + alerts are getting triggered in Prometheus
