### PR TITLE
Track coverage in Pull Requests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,6 +15,6 @@ jobs:
         fetch-depth: 10
 
     - uses: gwatts/go-coverage-action@v1
-      id: coverage
+      continue-on-error: true
       with:
         cover-pkg: ./...

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   coverage:
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,19 @@
+name: "Go Coverage"
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 10
+
+    - uses: gwatts/go-coverage-action@v1
+      id: coverage
+      with:
+        cover-pkg: ./...


### PR DESCRIPTION
# Description

This is a maintenance-oriented PR to give more confidence/trust into the code generation parts of Autometrics.

The goal is not to reach any fixed threshold of coverage, but rather give insights into the parts of the library
that are tested. Decent coverage of a feature, means more protection against regressions/breaking changes.

- Add more input validation tests
- Add coverage step in CI for PRs

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] ~~The CHANGELOG is updated.~~
- [x] ~~The open-telemetry example in repository works fine:~~
  + the docker compose file is valid
  + the application compiles and run
  + alerts are getting triggered in Prometheus
