### PR TITLE
Add support for passing traceID/spanID in generated metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,22 @@ versioning](https://go.dev/doc/modules/version-numbers).
 
 ### Added
 
+- Support for tracing-like exemplars in metrics. When using the Prometheus
+  instrumentation implementation, `trace_id`, `span_id`, and `parent_id` (for
+  the parent span) are added as exemplars to the metrics when they are observed.
+  Note that the Prometheus server needs to be [configured
+  specifically](https://prometheus.io/docs/prometheus/latest/feature_flags/#exemplars-storage)
+  to read the exemplars.
+- Added new options to context constructors to manipulate the tracing
+  information.
+
 ### Changed
+
+- The runtime autometrics.Context structure now can be used anywhere a
+  `context.Context` can, and will automatically embed a copy of the context
+  present in the annotated function arguments, when relevant.
+- The Context constructor changed signature to allow inclusion of a parent
+  context.
 
 ### Deprecated
 

--- a/docker-compose.prometheus-example.yaml
+++ b/docker-compose.prometheus-example.yaml
@@ -38,6 +38,7 @@ services:
       - ./examples/web/configs/autometrics.rules.yml:/etc/prometheus/autometrics.rules.yml
     command:
       - '--config.file=/etc/prometheus/prometheus.yaml'
+      - '--enable-feature=exemplar-storage'
     expose:
       - 9090
     ports:

--- a/examples/web/cmd/main.go
+++ b/examples/web/cmd/main.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	autometrics "github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -40,7 +41,11 @@ func main() {
 
 	http.HandleFunc("/", errorable(indexHandler))
 	http.HandleFunc("/random-error", errorable(randomErrorHandler))
-	http.Handle("/metrics", promhttp.Handler())
+	http.Handle("/metrics", promhttp.HandlerFor(
+		prometheus.DefaultGatherer,
+		promhttp.HandlerOpts{
+			EnableOpenMetrics: true,
+		}))
 
 	log.Println("binding on http://localhost:62086")
 	log.Fatal(http.ListenAndServe(":62086", nil))
@@ -63,10 +68,12 @@ func main() {
 //   - [Concurrent Calls]
 //
 // Or, dig into the metrics of *functions called by* `indexHandler`
+//
 //   - [Request Rate Callee]
+//
 //   - [Error Ratio Callee]
 //
-//	autometrics:doc-end Generated documentation by Autometrics.
+//     autometrics:doc-end Generated documentation by Autometrics.
 //
 // [Request Rate]: http://localhost:9090/graph?g0.expr=%23+Rate+of+calls+to+the+%60indexHandler%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count%7Bfunction%3D%22indexHandler%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0
 // [Error Ratio]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+calls+to+the+%60indexHandler%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0A%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count%7Bfunction%3D%22indexHandler%22%2Cresult%3D%22error%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29+%2F+%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count%7Bfunction%3D%22indexHandler%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29&g0.tab=0
@@ -75,9 +82,10 @@ func main() {
 // [Request Rate Callee]: http://localhost:9090/graph?g0.expr=%23+Rate+of+function+calls+emanating+from+%60indexHandler%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count%7Bcaller%3D%22main.indexHandler%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0
 // [Error Ratio Callee]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+function+emanating+from+%60indexHandler%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0A%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count%7Bcaller%3D%22main.indexHandler%22%2Cresult%3D%22error%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29+%2F+%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count%7Bcaller%3D%22main.indexHandler%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29&g0.tab=0
 //
-//autometrics:doc --slo "API" --latency-target 99 --latency-ms 100
-func indexHandler(w http.ResponseWriter, _ *http.Request) error {
+//autometrics:inst --slo "API" --latency-target 99 --latency-ms 100
+func indexHandler(w http.ResponseWriter, r *http.Request) error {
 	defer autometrics.Instrument(autometrics.PreInstrument(autometrics.NewContext(
+		r.Context(),
 		autometrics.WithConcurrentCalls(true),
 		autometrics.WithCallerName(true),
 		autometrics.WithSloName("API"),
@@ -86,7 +94,10 @@ func indexHandler(w http.ResponseWriter, _ *http.Request) error {
 
 	time.Sleep(time.Duration(rand.Intn(200)) * time.Millisecond)
 
-	_, err := fmt.Fprintf(w, "Hello, World!\n")
+	fmt.Fprintf(w, "Hello, World!\n")
+
+	err := randomErrorHandler(w, r)
+
 	return err
 }
 
@@ -94,36 +105,12 @@ var handlerError = errors.New("failed to handle request")
 
 // randomErrorHandler handles the /random-error route.
 //
-// It returns an error around 50% of the time.
+// It returns an error around 90% of the time.
 //
-//	autometrics:doc-start Generated documentation by Autometrics.
-//
-// # Autometrics
-//
-// # Prometheus
-//
-// View the live metrics for the `randomErrorHandler` function:
-//   - [Request Rate]
-//   - [Error Ratio]
-//   - [Latency (95th and 99th percentiles)]
-//   - [Concurrent Calls]
-//
-// Or, dig into the metrics of *functions called by* `randomErrorHandler`
-//   - [Request Rate Callee]
-//   - [Error Ratio Callee]
-//
-//	autometrics:doc-end Generated documentation by Autometrics.
-//
-// [Request Rate]: http://localhost:9090/graph?g0.expr=%23+Rate+of+calls+to+the+%60randomErrorHandler%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count%7Bfunction%3D%22randomErrorHandler%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0
-// [Error Ratio]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+calls+to+the+%60randomErrorHandler%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0A%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count%7Bfunction%3D%22randomErrorHandler%22%2Cresult%3D%22error%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29+%2F+%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count%7Bfunction%3D%22randomErrorHandler%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29&g0.tab=0
-// [Latency (95th and 99th percentiles)]: http://localhost:9090/graph?g0.expr=%23+95th+and+99th+percentile+latencies+%28in+seconds%29+for+the+%60randomErrorHandler%60+function%0A%0Alabel_replace%28histogram_quantile%280.99%2C+sum+by+%28le%2C+function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22randomErrorHandler%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29%2C+%22percentile_latency%22%2C+%2299%22%2C+%22%22%2C+%22%22%29+or+label_replace%28histogram_quantile%280.95%2C+sum+by+%28le%2C+function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22randomErrorHandler%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29%2C%22percentile_latency%22%2C+%2295%22%2C+%22%22%2C+%22%22%29&g0.tab=0
-// [Concurrent Calls]: http://localhost:9090/graph?g0.expr=%23+Concurrent+calls+to+the+%60randomErrorHandler%60+function%0A%0Asum+by+%28function%2C+module%2C+version%2C+commit%29+%28function_calls_concurrent%7Bfunction%3D%22randomErrorHandler%22%7D+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0
-// [Request Rate Callee]: http://localhost:9090/graph?g0.expr=%23+Rate+of+function+calls+emanating+from+%60randomErrorHandler%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count%7Bcaller%3D%22main.randomErrorHandler%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0
-// [Error Ratio Callee]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+function+emanating+from+%60randomErrorHandler%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0A%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count%7Bcaller%3D%22main.randomErrorHandler%22%2Cresult%3D%22error%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29+%2F+%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count%7Bcaller%3D%22main.randomErrorHandler%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29&g0.tab=0
-//
-//autometrics:doc --slo "API" --success-target 90
-func randomErrorHandler(w http.ResponseWriter, _ *http.Request) (err error) {
+//autometrics:inst --no-doc --slo "API" --success-target 90
+func randomErrorHandler(w http.ResponseWriter, r *http.Request) (err error) {
 	defer autometrics.Instrument(autometrics.PreInstrument(autometrics.NewContext(
+		r.Context(),
 		autometrics.WithConcurrentCalls(true),
 		autometrics.WithCallerName(true),
 		autometrics.WithSloName("API"),
@@ -144,7 +131,8 @@ func randomErrorHandler(w http.ResponseWriter, _ *http.Request) (err error) {
 // errorable is a wrapper to allow using functions that return `error` in route handlers.
 func errorable(handler func(w http.ResponseWriter, r *http.Request) error) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if err := handler(w, r); err != nil {
+		ctx := autometrics.WithNewTraceId(r.Context())
+		if err := handler(w, r.WithContext(ctx)); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 	}

--- a/examples/web/cmd/main.go.orig
+++ b/examples/web/cmd/main.go.orig
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	autometrics "github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -40,7 +41,11 @@ func main() {
 
 	http.HandleFunc("/", errorable(indexHandler))
 	http.HandleFunc("/random-error", errorable(randomErrorHandler))
-	http.Handle("/metrics", promhttp.Handler())
+	http.Handle("/metrics", promhttp.HandlerFor(
+		prometheus.DefaultGatherer,
+		promhttp.HandlerOpts{
+			EnableOpenMetrics: true,
+		}))
 
 	log.Println("binding on http://localhost:62086")
 	log.Fatal(http.ListenAndServe(":62086", nil))
@@ -50,12 +55,15 @@ func main() {
 //
 // It always succeeds and says hello.
 //
-//autometrics:doc --slo "API" --latency-target 99 --latency-ms 100
-func indexHandler(w http.ResponseWriter, _ *http.Request) error {
+//autometrics:inst --slo "API" --latency-target 99 --latency-ms 100
+func indexHandler(w http.ResponseWriter, r *http.Request) error {
 
 	time.Sleep(time.Duration(rand.Intn(200)) * time.Millisecond)
 
 	_, err := fmt.Fprintf(w, "Hello, World!\n")
+
+	err := randomErrorHandler(w, r)
+
 	return err
 }
 
@@ -63,10 +71,10 @@ var handlerError = errors.New("failed to handle request")
 
 // randomErrorHandler handles the /random-error route.
 //
-// It returns an error around 50% of the time.
+// It returns an error around 90% of the time.
 //
-//autometrics:doc --slo "API" --success-target 90
-func randomErrorHandler(w http.ResponseWriter, _ *http.Request) (err error) {
+//autometrics:inst --no-doc --slo "API" --success-target 90
+func randomErrorHandler(w http.ResponseWriter, r *http.Request) (err error) {
 	isOk := rand.Intn(10) == 0
 
 	if !isOk {

--- a/internal/autometrics/ctx.go
+++ b/internal/autometrics/ctx.go
@@ -2,6 +2,7 @@ package autometrics // import "github.com/autometrics-dev/autometrics-go/interna
 
 import (
 	"fmt"
+	"log"
 	"net/url"
 
 	"github.com/autometrics-dev/autometrics-go/pkg/autometrics"
@@ -12,8 +13,8 @@ import (
 // This context contains all the information necessary to properly process the `autometrics` directives over
 // each instrumented function in the file.
 type GeneratorContext struct {
-	// RuntimeCtx holds the runtime context to build from in the generated code.
-	RuntimeCtx autometrics.Context
+	// RuntimeCtx holds the information about the runtime context to build from in the generated code.
+	RuntimeCtx RuntimeCtxInfo
 	// FuncCtx holds the function specific information for the detected autometrics directive.
 	//
 	// Notably, it contains all the data relative to the parsing of the arguments in the directive.
@@ -28,13 +29,106 @@ type GeneratorContext struct {
 	//
 	// This can be set in the command for the generator or through the environment.
 	DisableDocGeneration bool
+	// ImportMap maps the alias to import in the current file, to canonical names associated with that name.
+	ImportsMap map[string]string
+}
+
+// This is almost a carbon copy of the autometrics.Context structure, except that
+// non-literal types are transcribed to strings to make it possible to reason about
+// the runtime context within generator logic.
+// Also, all the information that only gets filled at runtime is simply ignored, as
+// only statically-known information is useful at this point.
+type RuntimeCtxInfo struct {
+	// Name of the variable to use as context.Context when building the autometrics.Context.
+	// The string will be empty iff 'nil' must be used as autometrics.NewContext() argument.
+	ContextVariableName string
+	// Verbatim code to use to fetch the TraceID.
+	// For example, if the instrumented function is detected to use Gin, like
+	// `func ginHandler(ginVarName *gin.Context)`
+	// then the code in that variable should be something like
+	// `"autometrics.DecodeString(ginVarName.GetString(\"TraceID\"))"`
+	// This getter should return []byte to allow PreInstrument to
+	// log warnings and fill the data manually if the getter returns nil.
+	TraceIDGetter        string
+	SpanIDGetter         string
+	TrackConcurrentCalls bool
+	TrackCallerName      bool
+	AlertConf            *autometrics.AlertConfiguration
+}
+
+func DefaultRuntimeCtxInfo() RuntimeCtxInfo {
+	return RuntimeCtxInfo{
+		TrackConcurrentCalls: true,
+		TrackCallerName:      true,
+		ContextVariableName:  "nil",
+	}
+}
+
+func (c RuntimeCtxInfo) Validate(allowCustomLatencies bool) error {
+	if c.AlertConf != nil {
+		if c.AlertConf.ServiceName == "" {
+			return fmt.Errorf("Cannot have an AlertConfiguration without a service name")
+		}
+
+		if c.AlertConf.Success != nil && c.AlertConf.Success.Objective <= 0 {
+			return fmt.Errorf("Cannot have a target success rate that is negative")
+		}
+
+		if c.AlertConf.Success != nil && c.AlertConf.Success.Objective <= 1 {
+			log.Println("Warning: the target success rate is between 0 and 1, which is between 0 and 1%%. '1' is 1%% not 100%%!")
+		}
+
+		if c.AlertConf.Success != nil && c.AlertConf.Success.Objective > 100 {
+			return fmt.Errorf("Cannot have a target success rate that is strictly greater than 100 (more than 100%%)")
+		}
+
+		if c.AlertConf.Success != nil && !contains(autometrics.DefObjectives, c.AlertConf.Success.Objective) {
+			return fmt.Errorf("Cannot have a target success rate that is not one of the predetermined ones by generated rules files (valid targets are %v)", autometrics.DefObjectives)
+		}
+
+		if c.AlertConf.Latency != nil {
+			if c.AlertConf.Latency.Objective <= 0 {
+				return fmt.Errorf("Cannot have a target for latency SLO that is negative")
+			}
+			if c.AlertConf.Latency.Objective <= 1 {
+				log.Println("Warning: the latency target success rate is between 0 and 1, which is between 0 and 1%%. '1' is 1%% not 100%%!")
+			}
+			if c.AlertConf.Latency.Objective > 100 {
+				return fmt.Errorf("Cannot have a target for latency SLO that is greater than 100 (more than 100%%)")
+			}
+			if !contains(autometrics.DefObjectives, c.AlertConf.Latency.Objective) {
+				return fmt.Errorf("Cannot have a target for latency SLO that is not one of the predetermined in the generated rules files (valid targets are %v)", autometrics.DefObjectives)
+			}
+			if c.AlertConf.Latency.Target <= 0 {
+				return fmt.Errorf("Cannot have a target latency SLO threshold that is negative (responses expected before the query)")
+			}
+			if !allowCustomLatencies && !contains(autometrics.DefBuckets, c.AlertConf.Latency.Target.Seconds()) {
+				return fmt.Errorf(
+					"Cannot have a target latency SLO threshold that does not match a bucket (valid threshold in seconds are %v). If you set custom latencies in your Init call, then you can add the %v flag to the //go:generate invocation to remove this error",
+					autometrics.DefBuckets,
+					autometrics.AllowCustomLatenciesFlag,
+				)
+			}
+		}
+	}
+
+	return nil
+}
+
+func contains[T comparable](s []T, e T) bool {
+	for _, v := range s {
+		if v == e {
+			return true
+		}
+	}
+	return false
 }
 
 type GeneratorFunctionContext struct {
-	CommentIndex   int
-	FunctionName   string
-	ModuleName     string
-	ImplImportName string
+	CommentIndex         int
+	FunctionName         string
+	ModuleName           string
+	ImplImportName       string
 	DisableDocGeneration bool
 }
 
@@ -53,8 +147,9 @@ func NewGeneratorContext(implementation autometrics.Implementation, prometheusUr
 		Implementation:       implementation,
 		AllowCustomLatencies: allowCustomLatencies,
 		DisableDocGeneration: disableDocGeneration,
-		RuntimeCtx:           autometrics.NewContext(),
+		RuntimeCtx:           DefaultRuntimeCtxInfo(),
 		FuncCtx:              GeneratorFunctionContext{},
+		ImportsMap:           make(map[string]string),
 	}
 
 	if prometheusUrl != "" {

--- a/internal/generate/defer.go
+++ b/internal/generate/defer.go
@@ -1,0 +1,361 @@
+package generate // import "github.com/autometrics-dev/autometrics-go/internal/generate"
+
+import (
+	"fmt"
+	"log"
+	"reflect"
+	"strings"
+
+	"golang.org/x/exp/slices"
+
+	internal "github.com/autometrics-dev/autometrics-go/internal/autometrics"
+	am "github.com/autometrics-dev/autometrics-go/pkg/autometrics"
+
+	"github.com/dave/dst"
+	"github.com/dave/dst/decorator"
+)
+
+const (
+	vanillaContext = "context"
+	gin            = "github.com/gin-gonic/gin"
+	buffalo        = "github.com/gobuffalo/buffalo"
+	echoV4         = "github.com/labstack/echo/v4"
+	netHttp        = "net/http"
+)
+
+// injectDeferStatement add all the necessary information into context to produce the correct defer instrumentation statement.
+func injectDeferStatement(ctx *internal.GeneratorContext, funcDeclaration *dst.FuncDecl) error {
+	err := detectContext(ctx, funcDeclaration)
+	if err != nil {
+		return fmt.Errorf("failed to get context for tracing: %w", err)
+	}
+	firstStatement := funcDeclaration.Body.List[0]
+	variable, err := errorReturnValueName(funcDeclaration)
+	if err != nil {
+		return fmt.Errorf("failed to get error return value name: %w", err)
+	}
+
+	if len(variable) == 0 {
+		variable = "nil"
+	} else {
+		variable = "&" + variable
+	}
+
+	autometricsDeferStatement, err := buildAutometricsDeferStatement(ctx, variable)
+	if err != nil {
+		return fmt.Errorf("failed to build the defer statement for instrumentation: %w", err)
+	}
+
+	if deferStatement, ok := firstStatement.(*dst.DeferStmt); ok {
+		decorations := deferStatement.Decorations().End
+
+		if slices.Contains(decorations.All(), "//autometrics:defer") {
+			funcDeclaration.Body.List[0] = &autometricsDeferStatement
+		} else {
+			funcDeclaration.Body.List = append([]dst.Stmt{&autometricsDeferStatement}, funcDeclaration.Body.List...)
+		}
+	} else {
+		funcDeclaration.Body.List = append([]dst.Stmt{&autometricsDeferStatement}, funcDeclaration.Body.List...)
+	}
+	return nil
+}
+
+// errorReturnValueName returns the name of the error return value if it exists.
+func errorReturnValueName(funcNode *dst.FuncDecl) (string, error) {
+	returnValues := funcNode.Type.Results
+	if returnValues == nil || returnValues.List == nil {
+		return "", nil
+	}
+
+	for _, field := range returnValues.List {
+		fieldType := field.Type
+		if spec, ok := fieldType.(*dst.Ident); ok {
+			if spec.Name == "error" {
+				// Assuming that the `error` type has 0 or 1 name before it.
+				if field.Names == nil {
+					return "", nil
+				} else if len(field.Names) > 1 {
+					return "", fmt.Errorf("expecting a single named `error` return value, got %d instead.", len(field.Names))
+				}
+				return field.Names[0].Name, nil
+			}
+		}
+	}
+
+	return "", nil
+}
+
+// buildAutometricsContextNode creates an AST node representing the runtime context to inject in the instrumented code.
+//
+// This AST node is later used to create the defer statement responsible for instrumenting the code.
+func buildAutometricsContextNode(agc *internal.GeneratorContext) (*dst.CallExpr, error) {
+	// Using https://github.com/dave/dst/issues/73 workaround
+
+	var options []string
+
+	if agc.RuntimeCtx.TraceIDGetter != "" {
+		options = append(options, fmt.Sprintf("%v.WithTraceID(%v)", agc.FuncCtx.ImplImportName, agc.RuntimeCtx.TraceIDGetter))
+	}
+	if agc.RuntimeCtx.SpanIDGetter != "" {
+		options = append(options, fmt.Sprintf("%v.WithSpanID(%v)", agc.FuncCtx.ImplImportName, agc.RuntimeCtx.SpanIDGetter))
+	}
+
+	options = append(options,
+		fmt.Sprintf("%v.WithConcurrentCalls(%#v)", agc.FuncCtx.ImplImportName, agc.RuntimeCtx.TrackConcurrentCalls),
+		fmt.Sprintf("%v.WithCallerName(%#v)", agc.FuncCtx.ImplImportName, agc.RuntimeCtx.TrackCallerName),
+	)
+
+	if agc.RuntimeCtx.AlertConf != nil {
+		options = append(options, fmt.Sprintf("%v.WithSloName(%#v)",
+			agc.FuncCtx.ImplImportName,
+			agc.RuntimeCtx.AlertConf.ServiceName,
+		))
+		if agc.RuntimeCtx.AlertConf.Latency != nil {
+			options = append(options, fmt.Sprintf("%v.WithAlertLatency(%#v * time.Nanosecond, %#v)",
+				agc.FuncCtx.ImplImportName,
+				agc.RuntimeCtx.AlertConf.Latency.Target,
+				agc.RuntimeCtx.AlertConf.Latency.Objective,
+			))
+		}
+		if agc.RuntimeCtx.AlertConf.Success != nil {
+			options = append(options, fmt.Sprintf("%v.WithAlertSuccess(%#v)",
+				agc.FuncCtx.ImplImportName,
+				agc.RuntimeCtx.AlertConf.Success.Objective))
+		}
+	}
+
+	var buf strings.Builder
+	_, err := fmt.Fprintf(
+		&buf,
+		`
+package main
+
+var dummy = %v.NewContext(
+	%s,
+`,
+		agc.FuncCtx.ImplImportName,
+		agc.RuntimeCtx.ContextVariableName,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not write string builder to build dummy source code: %w", err)
+	}
+
+	for _, o := range options {
+		_, err = fmt.Fprintf(&buf, "\t%s,\n", o)
+		if err != nil {
+			return nil, fmt.Errorf("could not write string builder to build dummy source code: %w", err)
+		}
+	}
+
+	_, err = fmt.Fprint(&buf, ")\n")
+	if err != nil {
+		return nil, fmt.Errorf("could not write string builder to build dummy source code: %w", err)
+	}
+
+	sourceCode := buf.String()
+	sourceAst, err := decorator.Parse(sourceCode)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"could not parse dummy code\n%s\n: %w",
+			sourceCode,
+			err,
+		)
+	}
+
+	genDeclNode, ok := sourceAst.Decls[0].(*dst.GenDecl)
+	if !ok {
+		return nil, fmt.Errorf("unexpected node in the dummy code (expected dst.GenDecl): %w", err)
+	}
+
+	specNode, ok := genDeclNode.Specs[0].(*dst.ValueSpec)
+	if !ok {
+		return nil, fmt.Errorf("unexpected node in the dummy code (expected dst.ValueSpec): %w", err)
+	}
+
+	callExpr, ok := specNode.Values[0].(*dst.CallExpr)
+	if !ok {
+		return nil, fmt.Errorf("unexpected node in the dummy code (expected dst.CallExpr): %w", err)
+	}
+
+	return callExpr, nil
+}
+
+// buildAutometricsDeferStatement builds the AST node for the defer instrumentation statement to be inserted.
+func buildAutometricsDeferStatement(ctx *internal.GeneratorContext, secondVar string) (dst.DeferStmt, error) {
+	preInstrumentArg, err := buildAutometricsContextNode(ctx)
+	if err != nil {
+		return dst.DeferStmt{}, fmt.Errorf("could not generate the runtime context value: %w", err)
+	}
+	statement := dst.DeferStmt{
+		Call: &dst.CallExpr{
+			Fun: dst.NewIdent(fmt.Sprintf("%v.Instrument", ctx.FuncCtx.ImplImportName)),
+			Args: []dst.Expr{
+				&dst.CallExpr{
+					Fun: dst.NewIdent(fmt.Sprintf("%v.PreInstrument", ctx.FuncCtx.ImplImportName)),
+					Args: []dst.Expr{
+						preInstrumentArg,
+					},
+				},
+				dst.NewIdent(secondVar),
+			},
+		},
+	}
+
+	statement.Decs.Before = dst.NewLine
+	statement.Decs.End = []string{"//autometrics:defer"}
+	statement.Decs.After = dst.EmptyLine
+	return statement, nil
+}
+
+// detectContextIdentImpl is a Context detection logic helper for arguments whose type is an identifier
+//
+// The function returns true when it found enough information to ask for iteration to stop.
+func detectContextIdentImpl(ctx *internal.GeneratorContext, argName string, ident *dst.Ident) (bool, error) {
+	typeName := ident.Name
+	// If argType is just a dst.Ident when parsing, that means
+	// it is a single identifier ('Context', _not_ 'context.Context').
+	// Therefore we can solely check imports that got imported as '.'
+	for alias, canonical := range ctx.ImportsMap {
+		if alias != "." {
+			continue
+		}
+
+		if canonical == vanillaContext && typeName == "Context" {
+			ctx.RuntimeCtx.ContextVariableName = argName
+			ctx.RuntimeCtx.SpanIDGetter = ""
+			ctx.RuntimeCtx.TraceIDGetter = ""
+			return true, nil
+		}
+
+		if canonical == netHttp && typeName == "Request" {
+			if argName == "_" {
+				log.Println("Warning: an unnamed net/http.Request has been detected. To make Autometrics reuse its context for tracing purposes, please name it, and run 'go generate' again")
+				ctx.RuntimeCtx.ContextVariableName = "nil"
+			} else {
+				ctx.RuntimeCtx.ContextVariableName = fmt.Sprintf("%s.Context()", argName)
+			}
+			ctx.RuntimeCtx.SpanIDGetter = ""
+			ctx.RuntimeCtx.TraceIDGetter = ""
+			return true, nil
+		}
+
+		if canonical == gin && typeName == "Context" {
+			ctx.RuntimeCtx.SpanIDGetter = fmt.Sprintf("%s.DecodeString(%s.GetString(%#v))", ctx.FuncCtx.ImplImportName, argName, am.MiddlewareSpanIDKey)
+			ctx.RuntimeCtx.TraceIDGetter = fmt.Sprintf("%s.DecodeString(%s.GetString(%#v))", ctx.FuncCtx.ImplImportName, argName, am.MiddlewareTraceIDKey)
+			return true, nil
+		}
+
+		// Buffalo context embeds a context.Context so it can work like vanilla
+		if canonical == buffalo && typeName == "Context" {
+			ctx.RuntimeCtx.ContextVariableName = argName
+			ctx.RuntimeCtx.SpanIDGetter = ""
+			ctx.RuntimeCtx.TraceIDGetter = ""
+			return true, nil
+		}
+
+		if canonical == echoV4 && typeName == "Context" {
+			ctx.RuntimeCtx.SpanIDGetter = fmt.Sprintf("%s.DecodeString(%s.Get(%#v))", ctx.FuncCtx.ImplImportName, argName, am.MiddlewareSpanIDKey)
+			ctx.RuntimeCtx.TraceIDGetter = fmt.Sprintf("%s.DecodeString(%s.Get(%#v))", ctx.FuncCtx.ImplImportName, argName, am.MiddlewareTraceIDKey)
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// detectContextIdentImpl is a Context detection logic helper for arguments whose type is a selector expression.
+//
+// The function returns true when it found enough information to ask for iteration to stop.
+func detectContextSelectorImpl(ctx *internal.GeneratorContext, argName string, selector *dst.SelectorExpr) (bool, error) {
+	typeName := selector.Sel.Name
+	if parent, p_ok := selector.X.(*dst.Ident); p_ok {
+		parentName := parent.Name
+		for alias, canonical := range ctx.ImportsMap {
+			if canonical == vanillaContext && parentName == alias && typeName == "Context" {
+				ctx.RuntimeCtx.ContextVariableName = argName
+				ctx.RuntimeCtx.SpanIDGetter = ""
+				ctx.RuntimeCtx.TraceIDGetter = ""
+				return true, nil
+			}
+
+			if canonical == netHttp && parentName == alias && typeName == "Request" {
+				ctx.RuntimeCtx.ContextVariableName = fmt.Sprintf("%s.Context()", argName)
+				if argName == "_" {
+					log.Println("Warning: an unnamed net/http.Request has been detected. To make Autometrics reuse its context for tracing purposes, please name it, and run 'go generate' again")
+					ctx.RuntimeCtx.ContextVariableName = "nil"
+				} else {
+					ctx.RuntimeCtx.ContextVariableName = fmt.Sprintf("%s.Context()", argName)
+				}
+				ctx.RuntimeCtx.SpanIDGetter = ""
+				ctx.RuntimeCtx.TraceIDGetter = ""
+				return true, nil
+			}
+
+			if canonical == gin && parentName == alias && typeName == "Context" {
+				ctx.RuntimeCtx.SpanIDGetter = fmt.Sprintf("%s.DecodeString(%s.GetString(%#v))", ctx.FuncCtx.ImplImportName, argName, am.MiddlewareSpanIDKey)
+				ctx.RuntimeCtx.TraceIDGetter = fmt.Sprintf("%s.DecodeString(%s.GetString(%#v))", ctx.FuncCtx.ImplImportName, argName, am.MiddlewareTraceIDKey)
+				return true, nil
+			}
+
+			// Buffalo context embeds a context.Context so it can work like vanilla
+			if canonical == buffalo && parentName == alias && typeName == "Context" {
+				ctx.RuntimeCtx.ContextVariableName = argName
+				ctx.RuntimeCtx.SpanIDGetter = ""
+				ctx.RuntimeCtx.TraceIDGetter = ""
+				return true, nil
+			}
+
+			if canonical == echoV4 && typeName == "Context" && (parentName == alias || parentName == "echo") {
+				ctx.RuntimeCtx.SpanIDGetter = fmt.Sprintf("%s.DecodeString(%s.Get(%#v))", ctx.FuncCtx.ImplImportName, argName, am.MiddlewareSpanIDKey)
+				ctx.RuntimeCtx.TraceIDGetter = fmt.Sprintf("%s.DecodeString(%s.Get(%#v))", ctx.FuncCtx.ImplImportName, argName, am.MiddlewareTraceIDKey)
+				return true, nil
+			}
+		}
+	} else {
+		// TODO: log that autometrics cannot detect multi-nested contexts instead of errorring
+		// continue
+		return true, fmt.Errorf("expecting parent to be an identifier, got %s instead", reflect.TypeOf(selector.X).String())
+	}
+	return false, nil
+}
+
+// detectContext modifies a RuntimeCtxInfo to inject context when detected in the function signature.
+func detectContext(ctx *internal.GeneratorContext, funcDeclaration *dst.FuncDecl) error {
+	arguments := funcDeclaration.Type.Params.List
+	for _, argGroup := range arguments {
+		if len(argGroup.Names) > 1 {
+			continue
+		}
+		argName := argGroup.Names[0].Name
+		if argGroup.Type == nil {
+			continue
+		}
+
+		if argType, ok := argGroup.Type.(*dst.Ident); ok {
+			if found, err := detectContextIdentImpl(ctx, argName, argType); found {
+				return err
+			}
+		} else if argType, ok := argGroup.Type.(*dst.SelectorExpr); ok {
+			if found, err := detectContextSelectorImpl(ctx, argName, argType); found {
+				return err
+			}
+		} else if argType, ok := argGroup.Type.(*dst.StarExpr); ok {
+			if ident, ok := argType.X.(*dst.Ident); ok {
+				if found, err := detectContextIdentImpl(ctx, argName, ident); found {
+					return err
+				}
+			} else if selector, ok := argType.X.(*dst.SelectorExpr); ok {
+				if found, err := detectContextSelectorImpl(ctx, argName, selector); found {
+					return err
+				}
+			} else {
+				return fmt.Errorf("expecting the type being pointed to to be an identifier, got %s instead", reflect.TypeOf(argType.X).String())
+			}
+		} else {
+			return fmt.Errorf("expecting the type of argGroup to be an identifier, got %s instead", reflect.TypeOf(argGroup.Type).String())
+		}
+	}
+
+	ctx.RuntimeCtx.ContextVariableName = "nil"
+	return nil
+}

--- a/internal/generate/defer_test.go
+++ b/internal/generate/defer_test.go
@@ -1,0 +1,878 @@
+package generate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	internal "github.com/autometrics-dev/autometrics-go/internal/autometrics"
+	"github.com/autometrics-dev/autometrics-go/pkg/autometrics"
+)
+
+// TestVanillaContext tests that autometrics correctly detects a context.Context in
+// a function signature.
+func TestVanillaContext(t *testing.T) {
+	sourceCode := `// This is the package comment.
+package main
+
+import (
+	"context"
+
+	prom "github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus"
+)
+
+// This comment is associated with the main function.
+//
+//autometrics:inst --no-doc --slo "Service Test" --success-target 99
+func main(thisIsAContext context.Context) {
+	fmt.Println(hello) // line comment 3
+}
+`
+
+	want := "// This is the package comment.\n" +
+		"package main\n" +
+		"\n" +
+		"import (\n" +
+		"\t\"context\"\n" +
+		"\n" +
+		"\tprom \"github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus\"\n" +
+		")\n" +
+		"\n" +
+		"// This comment is associated with the main function.\n" +
+		"//\n" +
+		"//autometrics:inst --no-doc --slo \"Service Test\" --success-target 99\n" +
+		"func main(thisIsAContext context.Context) {\n" +
+		"\tdefer prom.Instrument(prom.PreInstrument(prom.NewContext(\n" +
+		"\t\tthisIsAContext,\n" +
+		"\t\tprom.WithConcurrentCalls(true),\n" +
+		"\t\tprom.WithCallerName(true),\n" +
+		"\t\tprom.WithSloName(\"Service Test\"),\n" +
+		"\t\tprom.WithAlertSuccess(99),\n" +
+		"\t)), nil) //autometrics:defer\n" +
+		"\n" +
+		"	fmt.Println(hello) // line comment 3\n" +
+		"}\n"
+
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	if err != nil {
+		t.Fatalf("error creating the generation context: %s", err)
+	}
+
+	actual, err := GenerateDocumentationAndInstrumentation(ctx, sourceCode, "main")
+	if err != nil {
+		t.Fatalf("error generating the documentation: %s", err)
+	}
+
+	assert.Equal(t, want, actual, "The generated source code is not as expected.")
+}
+
+// TestVanillaContextRenamed tests that autometrics correctly detects a context.Context in
+// a function signature when the import is renamed.
+func TestVanillaContextRenamed(t *testing.T) {
+	sourceCode := `// This is the package comment.
+package main
+
+import (
+	vanilla "context"
+
+	prom "github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus"
+)
+
+// This comment is associated with the main function.
+//
+//autometrics:inst --no-doc --slo "Service Test" --success-target 99
+func main(thisIsAContext vanilla.Context) {
+	fmt.Println(hello) // line comment 3
+}
+`
+
+	want := "// This is the package comment.\n" +
+		"package main\n" +
+		"\n" +
+		"import (\n" +
+		"\tvanilla \"context\"\n" +
+		"\n" +
+		"\tprom \"github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus\"\n" +
+		")\n" +
+		"\n" +
+		"// This comment is associated with the main function.\n" +
+		"//\n" +
+		"//autometrics:inst --no-doc --slo \"Service Test\" --success-target 99\n" +
+		"func main(thisIsAContext vanilla.Context) {\n" +
+		"\tdefer prom.Instrument(prom.PreInstrument(prom.NewContext(\n" +
+		"\t\tthisIsAContext,\n" +
+		"\t\tprom.WithConcurrentCalls(true),\n" +
+		"\t\tprom.WithCallerName(true),\n" +
+		"\t\tprom.WithSloName(\"Service Test\"),\n" +
+		"\t\tprom.WithAlertSuccess(99),\n" +
+		"\t)), nil) //autometrics:defer\n" +
+		"\n" +
+		"	fmt.Println(hello) // line comment 3\n" +
+		"}\n"
+
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	if err != nil {
+		t.Fatalf("error creating the generation context: %s", err)
+	}
+
+	actual, err := GenerateDocumentationAndInstrumentation(ctx, sourceCode, "main")
+	if err != nil {
+		t.Fatalf("error generating the documentation: %s", err)
+	}
+
+	assert.Equal(t, want, actual, "The generated source code is not as expected.")
+}
+
+// TestVanillaContextAnonymous tests that autometrics correctly detects a context.Context in
+// a function signature when the import is anon.
+func TestVanillaContextAnonymous(t *testing.T) {
+	sourceCode := `// This is the package comment.
+package main
+
+import (
+	. "context"
+
+	prom "github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus"
+)
+
+// This comment is associated with the main function.
+//
+//autometrics:inst --no-doc --slo "Service Test" --success-target 99
+func main(thisIsAContext Context) {
+	fmt.Println(hello) // line comment 3
+}
+`
+
+	want := "// This is the package comment.\n" +
+		"package main\n" +
+		"\n" +
+		"import (\n" +
+		"\t. \"context\"\n" +
+		"\n" +
+		"\tprom \"github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus\"\n" +
+		")\n" +
+		"\n" +
+		"// This comment is associated with the main function.\n" +
+		"//\n" +
+		"//autometrics:inst --no-doc --slo \"Service Test\" --success-target 99\n" +
+		"func main(thisIsAContext Context) {\n" +
+		"\tdefer prom.Instrument(prom.PreInstrument(prom.NewContext(\n" +
+		"\t\tthisIsAContext,\n" +
+		"\t\tprom.WithConcurrentCalls(true),\n" +
+		"\t\tprom.WithCallerName(true),\n" +
+		"\t\tprom.WithSloName(\"Service Test\"),\n" +
+		"\t\tprom.WithAlertSuccess(99),\n" +
+		"\t)), nil) //autometrics:defer\n" +
+		"\n" +
+		"	fmt.Println(hello) // line comment 3\n" +
+		"}\n"
+
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	if err != nil {
+		t.Fatalf("error creating the generation context: %s", err)
+	}
+
+	actual, err := GenerateDocumentationAndInstrumentation(ctx, sourceCode, "main")
+	if err != nil {
+		t.Fatalf("error generating the documentation: %s", err)
+	}
+
+	assert.Equal(t, want, actual, "The generated source code is not as expected.")
+}
+
+// TestHttpRequestContext tests that autometrics correctly detects a http.Request in
+// a function signature.
+func TestHttpRequestContext(t *testing.T) {
+	sourceCode := `// This is the package comment.
+package main
+
+import (
+	"net/http"
+
+	prom "github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus"
+)
+
+// This comment is associated with the main function.
+//
+//autometrics:inst --no-doc --slo "Service Test" --success-target 99
+func main(w http.ResponseWriter, req *http.Request) {
+	fmt.Println(hello) // line comment 3
+}
+`
+
+	want := "// This is the package comment.\n" +
+		"package main\n" +
+		"\n" +
+		"import (\n" +
+		"\t\"net/http\"\n" +
+		"\n" +
+		"\tprom \"github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus\"\n" +
+		")\n" +
+		"\n" +
+		"// This comment is associated with the main function.\n" +
+		"//\n" +
+		"//autometrics:inst --no-doc --slo \"Service Test\" --success-target 99\n" +
+		"func main(w http.ResponseWriter, req *http.Request) {\n" +
+		"\tdefer prom.Instrument(prom.PreInstrument(prom.NewContext(\n" +
+		"\t\treq.Context(),\n" +
+		"\t\tprom.WithConcurrentCalls(true),\n" +
+		"\t\tprom.WithCallerName(true),\n" +
+		"\t\tprom.WithSloName(\"Service Test\"),\n" +
+		"\t\tprom.WithAlertSuccess(99),\n" +
+		"\t)), nil) //autometrics:defer\n" +
+		"\n" +
+		"	fmt.Println(hello) // line comment 3\n" +
+		"}\n"
+
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	if err != nil {
+		t.Fatalf("error creating the generation context: %s", err)
+	}
+
+	actual, err := GenerateDocumentationAndInstrumentation(ctx, sourceCode, "main")
+	if err != nil {
+		t.Fatalf("error generating the documentation: %s", err)
+	}
+
+	assert.Equal(t, want, actual, "The generated source code is not as expected.")
+}
+
+// TestHttpRequestContextRenamed tests that autometrics correctly detects a http.Request in
+// a function signature when the import is renamed.
+func TestHttpRequestContextRenamed(t *testing.T) {
+	sourceCode := `// This is the package comment.
+package main
+
+import (
+	vanilla "net/http"
+
+	prom "github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus"
+)
+
+// This comment is associated with the main function.
+//
+//autometrics:inst --no-doc --slo "Service Test" --success-target 99
+func main(w vanilla.ResponseWriter, req *vanilla.Request) {
+	fmt.Println(hello) // line comment 3
+}
+`
+
+	want := "// This is the package comment.\n" +
+		"package main\n" +
+		"\n" +
+		"import (\n" +
+		"\tvanilla \"net/http\"\n" +
+		"\n" +
+		"\tprom \"github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus\"\n" +
+		")\n" +
+		"\n" +
+		"// This comment is associated with the main function.\n" +
+		"//\n" +
+		"//autometrics:inst --no-doc --slo \"Service Test\" --success-target 99\n" +
+		"func main(w vanilla.ResponseWriter, req *vanilla.Request) {\n" +
+		"\tdefer prom.Instrument(prom.PreInstrument(prom.NewContext(\n" +
+		"\t\treq.Context(),\n" +
+		"\t\tprom.WithConcurrentCalls(true),\n" +
+		"\t\tprom.WithCallerName(true),\n" +
+		"\t\tprom.WithSloName(\"Service Test\"),\n" +
+		"\t\tprom.WithAlertSuccess(99),\n" +
+		"\t)), nil) //autometrics:defer\n" +
+		"\n" +
+		"	fmt.Println(hello) // line comment 3\n" +
+		"}\n"
+
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	if err != nil {
+		t.Fatalf("error creating the generation context: %s", err)
+	}
+
+	actual, err := GenerateDocumentationAndInstrumentation(ctx, sourceCode, "main")
+	if err != nil {
+		t.Fatalf("error generating the documentation: %s", err)
+	}
+
+	assert.Equal(t, want, actual, "The generated source code is not as expected.")
+}
+
+// TestHttpRequestContextAnonymous tests that autometrics correctly detects a http.Request in
+// a function signature when the import is anon.
+func TestHttpRequestContextAnonymous(t *testing.T) {
+	sourceCode := `// This is the package comment.
+package main
+
+import (
+	. "net/http"
+
+	prom "github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus"
+)
+
+// This comment is associated with the main function.
+//
+//autometrics:inst --no-doc --slo "Service Test" --success-target 99
+func main(w ResponseWriter, req *Request) {
+	fmt.Println(hello) // line comment 3
+}
+`
+
+	want := "// This is the package comment.\n" +
+		"package main\n" +
+		"\n" +
+		"import (\n" +
+		"\t. \"net/http\"\n" +
+		"\n" +
+		"\tprom \"github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus\"\n" +
+		")\n" +
+		"\n" +
+		"// This comment is associated with the main function.\n" +
+		"//\n" +
+		"//autometrics:inst --no-doc --slo \"Service Test\" --success-target 99\n" +
+		"func main(w ResponseWriter, req *Request) {\n" +
+		"\tdefer prom.Instrument(prom.PreInstrument(prom.NewContext(\n" +
+		"\t\treq.Context(),\n" +
+		"\t\tprom.WithConcurrentCalls(true),\n" +
+		"\t\tprom.WithCallerName(true),\n" +
+		"\t\tprom.WithSloName(\"Service Test\"),\n" +
+		"\t\tprom.WithAlertSuccess(99),\n" +
+		"\t)), nil) //autometrics:defer\n" +
+		"\n" +
+		"	fmt.Println(hello) // line comment 3\n" +
+		"}\n"
+
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	if err != nil {
+		t.Fatalf("error creating the generation context: %s", err)
+	}
+
+	actual, err := GenerateDocumentationAndInstrumentation(ctx, sourceCode, "main")
+	if err != nil {
+		t.Fatalf("error generating the documentation: %s", err)
+	}
+
+	assert.Equal(t, want, actual, "The generated source code is not as expected.")
+}
+
+// TestBuffaloContext tests that autometrics correctly detects a buffalo.Context in
+// a function signature.
+func TestBuffaloContext(t *testing.T) {
+	sourceCode := `// This is the package comment.
+package main
+
+import (
+	"github.com/gobuffalo/buffalo"
+
+	prom "github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus"
+)
+
+// This comment is associated with the main function.
+//
+//autometrics:inst --no-doc --slo "Service Test" --success-target 99
+func main(thisIsAContext buffalo.Context) {
+	fmt.Println(hello) // line comment 3
+}
+`
+
+	want := "// This is the package comment.\n" +
+		"package main\n" +
+		"\n" +
+		"import (\n" +
+		"\t\"github.com/gobuffalo/buffalo\"\n" +
+		"\n" +
+		"\tprom \"github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus\"\n" +
+		")\n" +
+		"\n" +
+		"// This comment is associated with the main function.\n" +
+		"//\n" +
+		"//autometrics:inst --no-doc --slo \"Service Test\" --success-target 99\n" +
+		"func main(thisIsAContext buffalo.Context) {\n" +
+		"\tdefer prom.Instrument(prom.PreInstrument(prom.NewContext(\n" +
+		"\t\tthisIsAContext,\n" +
+		"\t\tprom.WithConcurrentCalls(true),\n" +
+		"\t\tprom.WithCallerName(true),\n" +
+		"\t\tprom.WithSloName(\"Service Test\"),\n" +
+		"\t\tprom.WithAlertSuccess(99),\n" +
+		"\t)), nil) //autometrics:defer\n" +
+		"\n" +
+		"	fmt.Println(hello) // line comment 3\n" +
+		"}\n"
+
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	if err != nil {
+		t.Fatalf("error creating the generation context: %s", err)
+	}
+
+	actual, err := GenerateDocumentationAndInstrumentation(ctx, sourceCode, "main")
+	if err != nil {
+		t.Fatalf("error generating the documentation: %s", err)
+	}
+
+	assert.Equal(t, want, actual, "The generated source code is not as expected.")
+}
+
+// TestBuffaloContextRenamed tests that autometrics correctly detects a buffalo.Context in
+// a function signature when the import is renamed.
+func TestBuffaloContextRenamed(t *testing.T) {
+	sourceCode := `// This is the package comment.
+package main
+
+import (
+	vanilla "github.com/gobuffalo/buffalo"
+
+	prom "github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus"
+)
+
+// This comment is associated with the main function.
+//
+//autometrics:inst --no-doc --slo "Service Test" --success-target 99
+func main(thisIsAContext vanilla.Context) {
+	fmt.Println(hello) // line comment 3
+}
+`
+
+	want := "// This is the package comment.\n" +
+		"package main\n" +
+		"\n" +
+		"import (\n" +
+		"\tvanilla \"github.com/gobuffalo/buffalo\"\n" +
+		"\n" +
+		"\tprom \"github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus\"\n" +
+		")\n" +
+		"\n" +
+		"// This comment is associated with the main function.\n" +
+		"//\n" +
+		"//autometrics:inst --no-doc --slo \"Service Test\" --success-target 99\n" +
+		"func main(thisIsAContext vanilla.Context) {\n" +
+		"\tdefer prom.Instrument(prom.PreInstrument(prom.NewContext(\n" +
+		"\t\tthisIsAContext,\n" +
+		"\t\tprom.WithConcurrentCalls(true),\n" +
+		"\t\tprom.WithCallerName(true),\n" +
+		"\t\tprom.WithSloName(\"Service Test\"),\n" +
+		"\t\tprom.WithAlertSuccess(99),\n" +
+		"\t)), nil) //autometrics:defer\n" +
+		"\n" +
+		"	fmt.Println(hello) // line comment 3\n" +
+		"}\n"
+
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	if err != nil {
+		t.Fatalf("error creating the generation context: %s", err)
+	}
+
+	actual, err := GenerateDocumentationAndInstrumentation(ctx, sourceCode, "main")
+	if err != nil {
+		t.Fatalf("error generating the documentation: %s", err)
+	}
+
+	assert.Equal(t, want, actual, "The generated source code is not as expected.")
+}
+
+// TestBuffaloContextAnonymous tests that autometrics correctly detects a buffalo.Context in
+// a function signature when the import is anon.
+func TestBuffaloContextAnonymous(t *testing.T) {
+	sourceCode := `// This is the package comment.
+package main
+
+import (
+	. "github.com/gobuffalo/buffalo"
+
+	prom "github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus"
+)
+
+// This comment is associated with the main function.
+//
+//autometrics:inst --no-doc --slo "Service Test" --success-target 99
+func main(thisIsAContext Context) {
+	fmt.Println(hello) // line comment 3
+}
+`
+
+	want := "// This is the package comment.\n" +
+		"package main\n" +
+		"\n" +
+		"import (\n" +
+		"\t. \"github.com/gobuffalo/buffalo\"\n" +
+		"\n" +
+		"\tprom \"github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus\"\n" +
+		")\n" +
+		"\n" +
+		"// This comment is associated with the main function.\n" +
+		"//\n" +
+		"//autometrics:inst --no-doc --slo \"Service Test\" --success-target 99\n" +
+		"func main(thisIsAContext Context) {\n" +
+		"\tdefer prom.Instrument(prom.PreInstrument(prom.NewContext(\n" +
+		"\t\tthisIsAContext,\n" +
+		"\t\tprom.WithConcurrentCalls(true),\n" +
+		"\t\tprom.WithCallerName(true),\n" +
+		"\t\tprom.WithSloName(\"Service Test\"),\n" +
+		"\t\tprom.WithAlertSuccess(99),\n" +
+		"\t)), nil) //autometrics:defer\n" +
+		"\n" +
+		"	fmt.Println(hello) // line comment 3\n" +
+		"}\n"
+
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	if err != nil {
+		t.Fatalf("error creating the generation context: %s", err)
+	}
+
+	actual, err := GenerateDocumentationAndInstrumentation(ctx, sourceCode, "main")
+	if err != nil {
+		t.Fatalf("error generating the documentation: %s", err)
+	}
+
+	assert.Equal(t, want, actual, "The generated source code is not as expected.")
+}
+
+// TestEchoContext tests that autometrics correctly detects an echo.Context in
+// a function signature.
+func TestEchoContext(t *testing.T) {
+	sourceCode := `// This is the package comment.
+package main
+
+import (
+	"github.com/labstack/echo/v4"
+
+	prom "github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus"
+)
+
+// This comment is associated with the main function.
+//
+//autometrics:inst --no-doc --slo "Service Test" --success-target 99
+func main(thisIsAContext echo.Context) {
+	fmt.Println(hello) // line comment 3
+}
+`
+
+	want := "// This is the package comment.\n" +
+		"package main\n" +
+		"\n" +
+		"import (\n" +
+		"\t\"github.com/labstack/echo/v4\"\n" +
+		"\n" +
+		"\tprom \"github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus\"\n" +
+		")\n" +
+		"\n" +
+		"// This comment is associated with the main function.\n" +
+		"//\n" +
+		"//autometrics:inst --no-doc --slo \"Service Test\" --success-target 99\n" +
+		"func main(thisIsAContext echo.Context) {\n" +
+		"\tdefer prom.Instrument(prom.PreInstrument(prom.NewContext(\n" +
+		"\t\tnil,\n" +
+		"\t\tprom.WithTraceID(prom.DecodeString(thisIsAContext.Get(\"autometricsTraceID\"))),\n" +
+		"\t\tprom.WithSpanID(prom.DecodeString(thisIsAContext.Get(\"autometricsSpanID\"))),\n" +
+		"\t\tprom.WithConcurrentCalls(true),\n" +
+		"\t\tprom.WithCallerName(true),\n" +
+		"\t\tprom.WithSloName(\"Service Test\"),\n" +
+		"\t\tprom.WithAlertSuccess(99),\n" +
+		"\t)), nil) //autometrics:defer\n" +
+		"\n" +
+		"	fmt.Println(hello) // line comment 3\n" +
+		"}\n"
+
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	if err != nil {
+		t.Fatalf("error creating the generation context: %s", err)
+	}
+
+	actual, err := GenerateDocumentationAndInstrumentation(ctx, sourceCode, "main")
+	if err != nil {
+		t.Fatalf("error generating the documentation: %s", err)
+	}
+
+	assert.Equal(t, want, actual, "The generated source code is not as expected.")
+}
+
+// TestEchoContextRenamed tests that autometrics correctly detects an echo.Context in
+// a function signature when the import is renamed.
+func TestEchoContextRenamed(t *testing.T) {
+	sourceCode := `// This is the package comment.
+package main
+
+import (
+	vanilla "github.com/labstack/echo/v4"
+
+	prom "github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus"
+)
+
+// This comment is associated with the main function.
+//
+//autometrics:inst --no-doc --slo "Service Test" --success-target 99
+func main(thisIsAContext vanilla.Context) {
+	fmt.Println(hello) // line comment 3
+}
+`
+
+	want := "// This is the package comment.\n" +
+		"package main\n" +
+		"\n" +
+		"import (\n" +
+		"\tvanilla \"github.com/labstack/echo/v4\"\n" +
+		"\n" +
+		"\tprom \"github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus\"\n" +
+		")\n" +
+		"\n" +
+		"// This comment is associated with the main function.\n" +
+		"//\n" +
+		"//autometrics:inst --no-doc --slo \"Service Test\" --success-target 99\n" +
+		"func main(thisIsAContext vanilla.Context) {\n" +
+		"\tdefer prom.Instrument(prom.PreInstrument(prom.NewContext(\n" +
+		"\t\tnil,\n" +
+		"\t\tprom.WithTraceID(prom.DecodeString(thisIsAContext.Get(\"autometricsTraceID\"))),\n" +
+		"\t\tprom.WithSpanID(prom.DecodeString(thisIsAContext.Get(\"autometricsSpanID\"))),\n" +
+		"\t\tprom.WithConcurrentCalls(true),\n" +
+		"\t\tprom.WithCallerName(true),\n" +
+		"\t\tprom.WithSloName(\"Service Test\"),\n" +
+		"\t\tprom.WithAlertSuccess(99),\n" +
+		"\t)), nil) //autometrics:defer\n" +
+		"\n" +
+		"	fmt.Println(hello) // line comment 3\n" +
+		"}\n"
+
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	if err != nil {
+		t.Fatalf("error creating the generation context: %s", err)
+	}
+
+	actual, err := GenerateDocumentationAndInstrumentation(ctx, sourceCode, "main")
+	if err != nil {
+		t.Fatalf("error generating the documentation: %s", err)
+	}
+
+	assert.Equal(t, want, actual, "The generated source code is not as expected.")
+}
+
+// TestEchoContextAnonymous tests that autometrics correctly detects an echo.Context in
+// a function signature when the import is anon.
+func TestEchoContextAnonymous(t *testing.T) {
+	sourceCode := `// This is the package comment.
+package main
+
+import (
+	. "github.com/labstack/echo/v4"
+
+	prom "github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus"
+)
+
+// This comment is associated with the main function.
+//
+//autometrics:inst --no-doc --slo "Service Test" --success-target 99
+func main(thisIsAContext Context) {
+	fmt.Println(hello) // line comment 3
+}
+`
+
+	want := "// This is the package comment.\n" +
+		"package main\n" +
+		"\n" +
+		"import (\n" +
+		"\t. \"github.com/labstack/echo/v4\"\n" +
+		"\n" +
+		"\tprom \"github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus\"\n" +
+		")\n" +
+		"\n" +
+		"// This comment is associated with the main function.\n" +
+		"//\n" +
+		"//autometrics:inst --no-doc --slo \"Service Test\" --success-target 99\n" +
+		"func main(thisIsAContext Context) {\n" +
+		"\tdefer prom.Instrument(prom.PreInstrument(prom.NewContext(\n" +
+		"\t\tnil,\n" +
+		"\t\tprom.WithTraceID(prom.DecodeString(thisIsAContext.Get(\"autometricsTraceID\"))),\n" +
+		"\t\tprom.WithSpanID(prom.DecodeString(thisIsAContext.Get(\"autometricsSpanID\"))),\n" +
+		"\t\tprom.WithConcurrentCalls(true),\n" +
+		"\t\tprom.WithCallerName(true),\n" +
+		"\t\tprom.WithSloName(\"Service Test\"),\n" +
+		"\t\tprom.WithAlertSuccess(99),\n" +
+		"\t)), nil) //autometrics:defer\n" +
+		"\n" +
+		"	fmt.Println(hello) // line comment 3\n" +
+		"}\n"
+
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	if err != nil {
+		t.Fatalf("error creating the generation context: %s", err)
+	}
+
+	actual, err := GenerateDocumentationAndInstrumentation(ctx, sourceCode, "main")
+	if err != nil {
+		t.Fatalf("error generating the documentation: %s", err)
+	}
+
+	assert.Equal(t, want, actual, "The generated source code is not as expected.")
+}
+
+// TestGinContext tests that autometrics correctly detects a gin.Context in
+// a function signature.
+func TestGinContext(t *testing.T) {
+	sourceCode := `// This is the package comment.
+package main
+
+import (
+	"github.com/gin-gonic/gin"
+
+	prom "github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus"
+)
+
+// This comment is associated with the main function.
+//
+//autometrics:inst --no-doc --slo "Service Test" --success-target 99
+func main(thisIsAContext *gin.Context) {
+	fmt.Println(hello) // line comment 3
+}
+`
+
+	want := "// This is the package comment.\n" +
+		"package main\n" +
+		"\n" +
+		"import (\n" +
+		"\t\"github.com/gin-gonic/gin\"\n" +
+		"\n" +
+		"\tprom \"github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus\"\n" +
+		")\n" +
+		"\n" +
+		"// This comment is associated with the main function.\n" +
+		"//\n" +
+		"//autometrics:inst --no-doc --slo \"Service Test\" --success-target 99\n" +
+		"func main(thisIsAContext *gin.Context) {\n" +
+		"\tdefer prom.Instrument(prom.PreInstrument(prom.NewContext(\n" +
+		"\t\tnil,\n" +
+		"\t\tprom.WithTraceID(prom.DecodeString(thisIsAContext.GetString(\"autometricsTraceID\"))),\n" +
+		"\t\tprom.WithSpanID(prom.DecodeString(thisIsAContext.GetString(\"autometricsSpanID\"))),\n" +
+		"\t\tprom.WithConcurrentCalls(true),\n" +
+		"\t\tprom.WithCallerName(true),\n" +
+		"\t\tprom.WithSloName(\"Service Test\"),\n" +
+		"\t\tprom.WithAlertSuccess(99),\n" +
+		"\t)), nil) //autometrics:defer\n" +
+		"\n" +
+		"	fmt.Println(hello) // line comment 3\n" +
+		"}\n"
+
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	if err != nil {
+		t.Fatalf("error creating the generation context: %s", err)
+	}
+
+	actual, err := GenerateDocumentationAndInstrumentation(ctx, sourceCode, "main")
+	if err != nil {
+		t.Fatalf("error generating the documentation: %s", err)
+	}
+
+	assert.Equal(t, want, actual, "The generated source code is not as expected.")
+}
+
+// TestGinContextRenamed tests that autometrics correctly detects a gin.Context in
+// a function signature when the import is renamed.
+func TestGinContextRenamed(t *testing.T) {
+	sourceCode := `// This is the package comment.
+package main
+
+import (
+	vanilla "github.com/gin-gonic/gin"
+
+	prom "github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus"
+)
+
+// This comment is associated with the main function.
+//
+//autometrics:inst --no-doc --slo "Service Test" --success-target 99
+func main(thisIsAContext *vanilla.Context) {
+	fmt.Println(hello) // line comment 3
+}
+`
+
+	want := "// This is the package comment.\n" +
+		"package main\n" +
+		"\n" +
+		"import (\n" +
+		"\tvanilla \"github.com/gin-gonic/gin\"\n" +
+		"\n" +
+		"\tprom \"github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus\"\n" +
+		")\n" +
+		"\n" +
+		"// This comment is associated with the main function.\n" +
+		"//\n" +
+		"//autometrics:inst --no-doc --slo \"Service Test\" --success-target 99\n" +
+		"func main(thisIsAContext *vanilla.Context) {\n" +
+		"\tdefer prom.Instrument(prom.PreInstrument(prom.NewContext(\n" +
+		"\t\tnil,\n" +
+		"\t\tprom.WithTraceID(prom.DecodeString(thisIsAContext.GetString(\"autometricsTraceID\"))),\n" +
+		"\t\tprom.WithSpanID(prom.DecodeString(thisIsAContext.GetString(\"autometricsSpanID\"))),\n" +
+		"\t\tprom.WithConcurrentCalls(true),\n" +
+		"\t\tprom.WithCallerName(true),\n" +
+		"\t\tprom.WithSloName(\"Service Test\"),\n" +
+		"\t\tprom.WithAlertSuccess(99),\n" +
+		"\t)), nil) //autometrics:defer\n" +
+		"\n" +
+		"	fmt.Println(hello) // line comment 3\n" +
+		"}\n"
+
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	if err != nil {
+		t.Fatalf("error creating the generation context: %s", err)
+	}
+
+	actual, err := GenerateDocumentationAndInstrumentation(ctx, sourceCode, "main")
+	if err != nil {
+		t.Fatalf("error generating the documentation: %s", err)
+	}
+
+	assert.Equal(t, want, actual, "The generated source code is not as expected.")
+}
+
+// TestGinContextAnonymous tests that autometrics correctly detects a gin.Context in
+// a function signature when the import is anon.
+func TestGinContextAnonymous(t *testing.T) {
+	sourceCode := `// This is the package comment.
+package main
+
+import (
+	. "github.com/gin-gonic/gin"
+
+	prom "github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus"
+)
+
+// This comment is associated with the main function.
+//
+//autometrics:inst --no-doc --slo "Service Test" --success-target 99
+func main(thisIsAContext *Context) {
+	fmt.Println(hello) // line comment 3
+}
+`
+
+	want := "// This is the package comment.\n" +
+		"package main\n" +
+		"\n" +
+		"import (\n" +
+		"\t. \"github.com/gin-gonic/gin\"\n" +
+		"\n" +
+		"\tprom \"github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus\"\n" +
+		")\n" +
+		"\n" +
+		"// This comment is associated with the main function.\n" +
+		"//\n" +
+		"//autometrics:inst --no-doc --slo \"Service Test\" --success-target 99\n" +
+		"func main(thisIsAContext *Context) {\n" +
+		"\tdefer prom.Instrument(prom.PreInstrument(prom.NewContext(\n" +
+		"\t\tnil,\n" +
+		"\t\tprom.WithTraceID(prom.DecodeString(thisIsAContext.GetString(\"autometricsTraceID\"))),\n" +
+		"\t\tprom.WithSpanID(prom.DecodeString(thisIsAContext.GetString(\"autometricsSpanID\"))),\n" +
+		"\t\tprom.WithConcurrentCalls(true),\n" +
+		"\t\tprom.WithCallerName(true),\n" +
+		"\t\tprom.WithSloName(\"Service Test\"),\n" +
+		"\t\tprom.WithAlertSuccess(99),\n" +
+		"\t)), nil) //autometrics:defer\n" +
+		"\n" +
+		"	fmt.Println(hello) // line comment 3\n" +
+		"}\n"
+
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	if err != nil {
+		t.Fatalf("error creating the generation context: %s", err)
+	}
+
+	actual, err := GenerateDocumentationAndInstrumentation(ctx, sourceCode, "main")
+	if err != nil {
+		t.Fatalf("error generating the documentation: %s", err)
+	}
+
+	assert.Equal(t, want, actual, "The generated source code is not as expected.")
+}
+

--- a/internal/generate/documentation.go
+++ b/internal/generate/documentation.go
@@ -1,0 +1,125 @@
+package generate // import "github.com/autometrics-dev/autometrics-go/internal/generate"
+
+import (
+	"fmt"
+	"strings"
+
+	internal "github.com/autometrics-dev/autometrics-go/internal/autometrics"
+
+	"github.com/dave/dst"
+)
+
+func cleanUpAutometricsComments(ctx internal.GeneratorContext, funcDeclaration *dst.FuncDecl) ([]string, error) {
+	docComments := funcDeclaration.Decorations().Start.All()
+	oldStartCommentIndices := autometricsDocStartDirectives(docComments)
+	oldEndCommentIndices := autometricsDocEndDirectives(docComments)
+
+	if len(oldStartCommentIndices) > 0 && len(oldEndCommentIndices) == 0 {
+		return nil, fmt.Errorf("Found an autometrics:doc-start cookie for function %s, but no matching :doc-end cookie", funcDeclaration.Name.Name)
+	}
+
+	if len(oldStartCommentIndices) == 0 && len(oldEndCommentIndices) > 0 {
+		return nil, fmt.Errorf("Found an autometrics:doc-end cookie for function %s, but no matching :doc-start cookie", funcDeclaration.Name.Name)
+	}
+
+	if len(oldStartCommentIndices) > 1 {
+		return nil, fmt.Errorf("Found more than 1 autometrics:doc-start cookie for function %s", funcDeclaration.Name.Name)
+	}
+
+	if len(oldEndCommentIndices) > 1 {
+		return nil, fmt.Errorf("Found more than 1 autometrics:doc-end cookie for function %s", funcDeclaration.Name.Name)
+	}
+
+	if len(oldStartCommentIndices) == 1 && len(oldEndCommentIndices) == 1 {
+		oldStartCommentIndex := oldStartCommentIndices[0]
+		oldEndCommentIndex := oldEndCommentIndices[0]
+
+		if oldStartCommentIndex >= 0 && oldEndCommentIndex <= oldStartCommentIndex {
+			return nil, fmt.Errorf("Found an autometrics cookies for function %s, but the end one is after the start one", funcDeclaration.Name.Name)
+		}
+
+		if oldStartCommentIndex >= 0 && oldEndCommentIndex > oldStartCommentIndex {
+			// We also remove the header and the footer that are used as block separation
+			docComments = append(docComments[:oldStartCommentIndex-1], docComments[oldEndCommentIndex+2:]...)
+
+			// Remove the generated links from former passes
+			if ctx.DocumentationGenerator != nil {
+				generatedLinks := ctx.DocumentationGenerator.GeneratedLinks()
+				docComments = filter(docComments, func(input string) bool {
+					for _, link := range generatedLinks {
+						if strings.Contains(input, fmt.Sprintf("[%s]", link)) {
+							return false
+						}
+					}
+					return true
+				})
+			}
+		}
+	}
+
+	return docComments, nil
+}
+
+// autometricsDocStartDirectives return the list of indices in the array where line is a comment start directive.
+func autometricsDocStartDirectives(commentGroup []string) []int {
+	var lines []int
+	for i, comment := range commentGroup {
+		if strings.Contains(comment, "autometrics:doc-start") {
+			lines = append(lines, i)
+		}
+	}
+
+	return lines
+}
+
+// autometricsDocStartDirectives return the list of indices in the array where line is a comment end directive.
+func autometricsDocEndDirectives(commentGroup []string) []int {
+	var lines []int
+	for i, comment := range commentGroup {
+		if strings.Contains(comment, "autometrics:doc-end") {
+			lines = append(lines, i)
+		}
+	}
+
+	return lines
+}
+
+func generateAutometricsComment(ctx internal.GeneratorContext) (commentLines []string) {
+	if ctx.DocumentationGenerator == nil {
+		return
+	}
+
+	l := ctx.DocumentationGenerator.GenerateAutometricsComment(
+		ctx,
+		ctx.FuncCtx.FunctionName,
+		ctx.FuncCtx.ModuleName,
+	)
+	commentLines = append(commentLines, "//")
+	commentLines = append(commentLines, "//\tautometrics:doc-start Generated documentation by Autometrics.")
+	commentLines = append(commentLines, "//")
+	commentLines = append(commentLines, "// # Autometrics")
+	commentLines = append(commentLines, "//")
+	commentLines = append(commentLines, l...)
+	commentLines = append(commentLines, "//")
+	commentLines = append(commentLines, "//\tautometrics:doc-end Generated documentation by Autometrics.")
+	commentLines = append(commentLines, "//")
+
+	return
+}
+
+func insertComments(inputArray []string, index int, values []string) []string {
+	if len(inputArray) == index { // nil or empty slice or after last element
+		return append(inputArray, values...)
+	}
+
+	beginning := inputArray[:index]
+	// Maybe the deep copy is not necessary, wasn't able to
+	// specify the semantics properly here.
+	end := make([]string, len(inputArray[index:]))
+	copy(end, inputArray[index:])
+
+	inputArray = append(beginning, values...)
+	inputArray = append(inputArray, end...)
+
+	return inputArray
+}

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/autometrics-dev/autometrics-go/pkg/autometrics"
 )
 
-const DefaultPrometheusInstanceUrl = "http://localhost:9090/"
+const defaultPrometheusInstanceUrl = "http://localhost:9090/"
 
 func TestCommentDirective(t *testing.T) {
 	sourceCode := `// This is the package comment.
@@ -60,16 +60,17 @@ func main() {
 		"//\n" +
 		"//\tautometrics:doc-end Generated documentation by Autometrics.\n" +
 		"//\n" +
-		"// [Request Rate]: http://localhost:9090/graph?g0.expr=%23+Rate+of+calls+to+the+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0\n" +
-		"// [Error Ratio]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+calls+to+the+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0A%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count%7Bfunction%3D%22main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29+%2F+%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29&g0.tab=0\n" +
+		"// [Request Rate]: http://localhost:9090/graph?g0.expr=%23+Rate+of+calls+to+the+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0\n" +
+		"// [Error Ratio]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+calls+to+the+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0A%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bfunction%3D%22main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29+%2F+%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29&g0.tab=0\n" +
 		"// [Latency (95th and 99th percentiles)]: http://localhost:9090/graph?g0.expr=%23+95th+and+99th+percentile+latencies+%28in+seconds%29+for+the+%60main%60+function%0A%0Alabel_replace%28histogram_quantile%280.99%2C+sum+by+%28le%2C+function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29%2C+%22percentile_latency%22%2C+%2299%22%2C+%22%22%2C+%22%22%29+or+label_replace%28histogram_quantile%280.95%2C+sum+by+%28le%2C+function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29%2C%22percentile_latency%22%2C+%2295%22%2C+%22%22%2C+%22%22%29&g0.tab=0\n" +
 		"// [Concurrent Calls]: http://localhost:9090/graph?g0.expr=%23+Concurrent+calls+to+the+%60main%60+function%0A%0Asum+by+%28function%2C+module%2C+version%2C+commit%29+%28function_calls_concurrent%7Bfunction%3D%22main%22%7D+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0\n" +
-		"// [Request Rate Callee]: http://localhost:9090/graph?g0.expr=%23+Rate+of+function+calls+emanating+from+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count%7Bcaller%3D%22main.main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0\n" +
-		"// [Error Ratio Callee]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+function+emanating+from+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0A%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count%7Bcaller%3D%22main.main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29+%2F+%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count%7Bcaller%3D%22main.main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29&g0.tab=0\n" +
+		"// [Request Rate Callee]: http://localhost:9090/graph?g0.expr=%23+Rate+of+function+calls+emanating+from+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bcaller%3D%22main.main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0\n" +
+		"// [Error Ratio Callee]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+function+emanating+from+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0A%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bcaller%3D%22main.main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29+%2F+%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bcaller%3D%22main.main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29&g0.tab=0\n" +
 		"//\n" +
 		"//autometrics:inst --slo \"Service Test\" --success-target 99\n" +
 		"func main() {\n" +
 		"\tdefer prom.Instrument(prom.PreInstrument(prom.NewContext(\n" +
+		"\t\tnil,\n" +
 		"\t\tprom.WithConcurrentCalls(true),\n" +
 		"\t\tprom.WithCallerName(true),\n" +
 		"\t\tprom.WithSloName(\"Service Test\"),\n" +
@@ -79,7 +80,7 @@ func main() {
 		"	fmt.Println(hello) // line comment 3\n" +
 		"}\n"
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, DefaultPrometheusInstanceUrl, false, false)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -144,16 +145,17 @@ func main() {
 		"//\n" +
 		"//\tautometrics:doc-end Generated documentation by Autometrics.\n" +
 		"//\n" +
-		"// [Request Rate]: http://localhost:9090/graph?g0.expr=%23+Rate+of+calls+to+the+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0\n" +
-		"// [Error Ratio]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+calls+to+the+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0A%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count%7Bfunction%3D%22main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29+%2F+%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29&g0.tab=0\n" +
+		"// [Request Rate]: http://localhost:9090/graph?g0.expr=%23+Rate+of+calls+to+the+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0\n" +
+		"// [Error Ratio]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+calls+to+the+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0A%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bfunction%3D%22main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29+%2F+%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29&g0.tab=0\n" +
 		"// [Latency (95th and 99th percentiles)]: http://localhost:9090/graph?g0.expr=%23+95th+and+99th+percentile+latencies+%28in+seconds%29+for+the+%60main%60+function%0A%0Alabel_replace%28histogram_quantile%280.99%2C+sum+by+%28le%2C+function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29%2C+%22percentile_latency%22%2C+%2299%22%2C+%22%22%2C+%22%22%29+or+label_replace%28histogram_quantile%280.95%2C+sum+by+%28le%2C+function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29%2C%22percentile_latency%22%2C+%2295%22%2C+%22%22%2C+%22%22%29&g0.tab=0\n" +
 		"// [Concurrent Calls]: http://localhost:9090/graph?g0.expr=%23+Concurrent+calls+to+the+%60main%60+function%0A%0Asum+by+%28function%2C+module%2C+version%2C+commit%29+%28function_calls_concurrent%7Bfunction%3D%22main%22%7D+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0\n" +
-		"// [Request Rate Callee]: http://localhost:9090/graph?g0.expr=%23+Rate+of+function+calls+emanating+from+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count%7Bcaller%3D%22main.main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0\n" +
-		"// [Error Ratio Callee]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+function+emanating+from+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0A%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count%7Bcaller%3D%22main.main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29+%2F+%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count%7Bcaller%3D%22main.main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29&g0.tab=0\n" +
+		"// [Request Rate Callee]: http://localhost:9090/graph?g0.expr=%23+Rate+of+function+calls+emanating+from+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bcaller%3D%22main.main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0\n" +
+		"// [Error Ratio Callee]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+function+emanating+from+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0A%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bcaller%3D%22main.main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29+%2F+%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bcaller%3D%22main.main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29&g0.tab=0\n" +
 		"//\n" +
 		"//autometrics:inst --slo \"API\" --latency-target 99.9 --latency-ms 500\n" +
 		"func main() {\n" +
 		"\tdefer prom.Instrument(prom.PreInstrument(prom.NewContext(\n" +
+		"\t\tnil,\n" +
 		"\t\tprom.WithConcurrentCalls(true),\n" +
 		"\t\tprom.WithCallerName(true),\n" +
 		"\t\tprom.WithSloName(\"API\"),\n" +
@@ -163,7 +165,7 @@ func main() {
 		"	fmt.Println(hello) // line comment 3\n" +
 		"}\n"
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, DefaultPrometheusInstanceUrl, false, false)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -210,6 +212,7 @@ func main() {
 		"//autometrics:inst --no-doc --slo \"API\" --latency-target 99.9 --latency-ms 500\n" +
 		"func main() {\n" +
 		"\tdefer prometheus.Instrument(prometheus.PreInstrument(prometheus.NewContext(\n" +
+		"\t\tnil,\n" +
 		"\t\tprometheus.WithConcurrentCalls(true),\n" +
 		"\t\tprometheus.WithCallerName(true),\n" +
 		"\t\tprometheus.WithSloName(\"API\"),\n" +
@@ -219,7 +222,7 @@ func main() {
 		"	fmt.Println(hello) // line comment 3\n" +
 		"}\n"
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, DefaultPrometheusInstanceUrl, false, false)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -272,6 +275,7 @@ func main() {
 		"//autometrics:inst --slo \"API\" --latency-target 99.9 --latency-ms 500\n" +
 		"func main() {\n" +
 		"\tdefer prom.Instrument(prom.PreInstrument(prom.NewContext(\n" +
+		"\t\tnil,\n" +
 		"\t\tprom.WithConcurrentCalls(true),\n" +
 		"\t\tprom.WithCallerName(true),\n" +
 		"\t\tprom.WithSloName(\"API\"),\n" +
@@ -281,7 +285,7 @@ func main() {
 		"	fmt.Println(hello) // line comment 3\n" +
 		"}\n"
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, DefaultPrometheusInstanceUrl, false, true)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -310,7 +314,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, DefaultPrometheusInstanceUrl, false, false)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -333,7 +337,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, DefaultPrometheusInstanceUrl, false, false)
+	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -355,7 +359,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, DefaultPrometheusInstanceUrl, false, false)
+	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -381,7 +385,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, DefaultPrometheusInstanceUrl, false, false)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -404,7 +408,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, DefaultPrometheusInstanceUrl, false, false)
+	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -427,7 +431,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, DefaultPrometheusInstanceUrl, false, false)
+	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -450,7 +454,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, DefaultPrometheusInstanceUrl, false, false)
+	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -473,7 +477,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, DefaultPrometheusInstanceUrl, false, false)
+	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -496,7 +500,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, DefaultPrometheusInstanceUrl, false, false)
+	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -519,7 +523,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, DefaultPrometheusInstanceUrl, false, false)
+	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -527,7 +531,7 @@ func main() {
 	_, err = GenerateDocumentationAndInstrumentation(ctx, sourceCode, "main")
 	assert.Error(t, err, "Calling generation must fail if latency target is not in the default buckets.")
 
-	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, DefaultPrometheusInstanceUrl, true, false)
+	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, true, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -555,7 +559,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, DefaultPrometheusInstanceUrl, false, false)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -579,7 +583,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, DefaultPrometheusInstanceUrl, false, false)
+	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -605,7 +609,7 @@ func main() {
 	fmt.Printstart ln(hello) // line comment 3
 }
 `
-	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, DefaultPrometheusInstanceUrl, false, false)
+	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -631,7 +635,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, DefaultPrometheusInstanceUrl, false, false)
+	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -656,7 +660,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, DefaultPrometheusInstanceUrl, false, false)
+	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -898,7 +902,7 @@ func main() (cannotGetLuckyCollision, otherError error) {
 	assert.Error(t, err, "Calling the named return detection must fail if there are multiple error values.")
 }
 
-func implementContextCodeGenTest(t *testing.T, contextToSerialize autometrics.Context, expected string) {
+func implementContextCodeGenTest(t *testing.T, contextToSerialize internal.RuntimeCtxInfo, expected string) {
 	sourceContext := internal.GeneratorContext{
 		RuntimeCtx: contextToSerialize,
 		FuncCtx: internal.GeneratorFunctionContext{
@@ -907,7 +911,7 @@ func implementContextCodeGenTest(t *testing.T, contextToSerialize autometrics.Co
 		},
 	}
 
-	node, err := buildAutometricsContextNode(sourceContext)
+	node, err := buildAutometricsContextNode(&sourceContext)
 	if err != nil {
 		t.Fatalf("error building the context node: %s", err)
 	}
@@ -952,8 +956,9 @@ var dummy2 = %v
 
 func TestNewContextCodeGen(t *testing.T) {
 	implementContextCodeGenTest(t,
-		autometrics.NewContext(),
+		internal.DefaultRuntimeCtxInfo(),
 		`autometrics.NewContext(
+	nil,
 	autometrics.WithConcurrentCalls(true),
 	autometrics.WithCallerName(true),
 )`,
@@ -961,12 +966,13 @@ func TestNewContextCodeGen(t *testing.T) {
 }
 
 func TestNoTrackContextCodeGen(t *testing.T) {
-	ctx := autometrics.NewContext()
+	ctx := internal.DefaultRuntimeCtxInfo()
 	ctx.TrackCallerName = false
 	ctx.TrackConcurrentCalls = false
 	implementContextCodeGenTest(t,
 		ctx,
 		`autometrics.NewContext(
+	nil,
 	autometrics.WithConcurrentCalls(false),
 	autometrics.WithCallerName(false),
 )`,
@@ -974,7 +980,7 @@ func TestNoTrackContextCodeGen(t *testing.T) {
 }
 
 func TestLatencyContextCodeGen(t *testing.T) {
-	ctx := autometrics.NewContext()
+	ctx := internal.DefaultRuntimeCtxInfo()
 	ctx.TrackCallerName = false
 	ctx.AlertConf = &autometrics.AlertConfiguration{
 		ServiceName: "api",
@@ -987,6 +993,7 @@ func TestLatencyContextCodeGen(t *testing.T) {
 	implementContextCodeGenTest(t,
 		ctx,
 		`autometrics.NewContext(
+	nil,
 	autometrics.WithConcurrentCalls(true),
 	autometrics.WithCallerName(false),
 	autometrics.WithSloName("api"),
@@ -996,7 +1003,7 @@ func TestLatencyContextCodeGen(t *testing.T) {
 }
 
 func TestSuccessContextCodeGen(t *testing.T) {
-	ctx := autometrics.NewContext()
+	ctx := internal.DefaultRuntimeCtxInfo()
 	ctx.TrackCallerName = false
 	ctx.AlertConf = &autometrics.AlertConfiguration{
 		ServiceName: "api",
@@ -1008,6 +1015,7 @@ func TestSuccessContextCodeGen(t *testing.T) {
 	implementContextCodeGenTest(t,
 		ctx,
 		`autometrics.NewContext(
+	nil,
 	autometrics.WithConcurrentCalls(true),
 	autometrics.WithCallerName(false),
 	autometrics.WithSloName("api"),

--- a/internal/generate/utils.go
+++ b/internal/generate/utils.go
@@ -1,0 +1,22 @@
+package generate // import "github.com/autometrics-dev/autometrics-go/internal/generate"
+
+import (
+	"strings"
+)
+
+// Backport of strings.CutPrefix for pre-1.20
+func cutPrefix(s, prefix string) (after string, found bool) {
+	if !strings.HasPrefix(s, prefix) {
+		return s, false
+	}
+	return s[len(prefix):], true
+}
+
+func filter(ss []string, test func(string) bool) (ret []string) {
+	for _, s := range ss {
+		if test(s) {
+			ret = append(ret, s)
+		}
+	}
+	return
+}

--- a/pkg/autometrics/ctx.go
+++ b/pkg/autometrics/ctx.go
@@ -153,7 +153,6 @@ func (c *Context) FillTracingInfo() {
 	_, _ = randSource.Read(sid[:])
 	c.SetSpanID(sid)
 
-	// REVIEW: we might not want to fill the trace ID if it is absent.
 	if _, ok := c.GetTraceID(); !ok {
 		tid := TraceID{}
 		_, _ = randSource.Read(tid[:])

--- a/pkg/autometrics/ctx.go
+++ b/pkg/autometrics/ctx.go
@@ -1,0 +1,191 @@
+package autometrics // import "github.com/autometrics-dev/autometrics-go/pkg/autometrics"
+
+import (
+	"context"
+	"math/rand"
+	"time"
+)
+
+type contextKey int
+
+const (
+	currentTraceId contextKey = iota
+	currentSpanId
+	parentSpanId
+)
+
+var randSource *rand.Rand
+
+// Open Telemetry-compatible trace ID
+type TraceID [16]byte
+
+// Open Telemetry-compatible span ID
+type SpanID [8]byte
+
+// Context holds the configuration
+// to instrument properly a function.
+//
+// This can be viewed as a context for the instrumentation calls
+type Context struct {
+	// Embedded context of the currently instrumented function.
+	//
+	// This allows the context to be passed around wherever a [context.Context] is expected.
+	context.Context
+	// TrackConcurrentCalls triggers the collection of the gauge for concurrent calls of the function.
+	TrackConcurrentCalls bool
+	// TrackCallerName adds a label with the caller name in all the collected metrics.
+	TrackCallerName bool
+	// AlertConf is an optional configuration to add alerting capabilities to the metrics.
+	AlertConf *AlertConfiguration
+	// StartTime is the start time of a single function execution.
+	// Only amImpl.Instrument should read this value.
+	// Only amImpl.PreInstrument should write this value.
+	//
+	// (amImpl is either the [Prometheus] or the [Open Telemetry] implementation)
+	//
+	// This value is only exported for the child packages [Prometheus] and [Open Telemetry]
+	//
+	// [Prometheus]: https://godoc.org/github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus
+	// [Open Telemetry]: https://godoc.org/github.com/autometrics-dev/autometrics-go/pkg/autometrics/otel
+	StartTime time.Time
+	// CallInfo contains all the relevant data for caller information.
+	// Only amImpl.Instrument should read this value.
+	// Only amImpl.PreInstrument should write/read this value.
+	//
+	// (amImpl is either the [Prometheus] or the [Open Telemetry] implementation)
+	//
+	// This value is only exported for the child packages [Prometheus] and [Open Telemetry]
+	//
+	// [Prometheus]: https://godoc.org/github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus
+	// [Open Telemetry]: https://godoc.org/github.com/autometrics-dev/autometrics-go/pkg/autometrics/otel
+	CallInfo CallInfo
+	// BuildInfo contains all the relevant data for caller information.
+	// Only amImpl.Instrument and PreInstrument should read this value.
+	// Only amImpl.Init should write/read this value.
+	//
+	// (amImpl is either the [Prometheus] or the [Open Telemetry] implementation)
+	//
+	// This value is only exported for the child packages [Prometheus] and [Open Telemetry]
+	//
+	// [Prometheus]: https://godoc.org/github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus
+	// [Open Telemetry]: https://godoc.org/github.com/autometrics-dev/autometrics-go/pkg/autometrics/otel
+	BuildInfo BuildInfo
+}
+
+// NewContext is a constructor taking the parent context as argument.
+//
+// It accepts 'nil' as the parent context. In this case the constructor
+// acts as if it received a new, fresh context.Background().
+func NewContext(parentCtx context.Context) Context {
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+	return Context{
+		TrackConcurrentCalls: true,
+		TrackCallerName:      true,
+		AlertConf:            nil,
+		Context:              parentCtx,
+	}
+}
+
+// SetTraceID sets the context's [TraceID]
+func (ctx *Context) SetTraceID(tid TraceID) {
+	ctx.Context = context.WithValue(ctx.Context, currentTraceId, tid)
+}
+
+// SetSpanID sets the context's [SpanID]
+func (ctx *Context) SetSpanID(sid SpanID) {
+	ctx.Context = context.WithValue(ctx.Context, currentSpanId, sid)
+}
+
+// SetParentSpanID sets the context's span's parent [SpanID]
+func (ctx *Context) SetParentSpanID(sid SpanID) {
+	ctx.Context = context.WithValue(ctx.Context, parentSpanId, sid)
+}
+
+// GetTraceID returns (_, false) if the context did not contain any trace id.
+func (c Context) GetTraceID() (TraceID, bool) {
+	if c.Context == nil {
+		return TraceID{}, false
+	}
+	tid, ok := c.Value(currentTraceId).(TraceID)
+	return tid, ok
+}
+
+// GetSpanID returns (_, false) if the context did not contain the current span id.
+func (c Context) GetSpanID() (SpanID, bool) {
+	if c.Context == nil {
+		return SpanID{}, false
+	}
+	sid, ok := c.Value(currentSpanId).(SpanID)
+	return sid, ok
+}
+
+// GetParentSpanID returns (_, false) if the context did not contain the parent's span id (including when we are in the root span).
+func (c Context) GetParentSpanID() (SpanID, bool) {
+	if c.Context == nil {
+		return SpanID{}, false
+	}
+	sid, ok := c.Value(parentSpanId).(SpanID)
+	return sid, ok
+}
+
+// FillTracingInfo ensures the context has a traceID and a spanID.
+// If they do not have this information, this method adds randomly
+// generated IDs in the context to be used later for exemplars
+//
+// The random generator is a PRNG, seeded with the timestamp of the first time new IDs are needed.
+func (c *Context) FillTracingInfo() {
+	// We are using a PRNG because FillTracingInfo is expected to be called in PreInstrument.
+	// Therefore it can have a noticeable impact on the performance of instrumented code.
+	// Pseudo randomness should be enough for our use cases, true randomness might introduce too much latency.
+	// randSource is initialized with a timestamp from the first time it is accessed in nanoseconds, which should
+	// be enough precision to avoid accidental collisions (imagine multiple services starting "at the same time" in a deployment).
+	if randSource == nil {
+		randSource = rand.New(rand.NewSource(time.Now().UnixNano()))
+	}
+
+	if parentSpanId, ok := c.GetSpanID(); ok {
+		c.SetParentSpanID(parentSpanId)
+	}
+
+	sid := SpanID{}
+	_, _ = randSource.Read(sid[:])
+	c.SetSpanID(sid)
+
+	// REVIEW: we might not want to fill the trace ID if it is absent.
+	if _, ok := c.GetTraceID(); !ok {
+		tid := TraceID{}
+		_, _ = randSource.Read(tid[:])
+		c.SetTraceID(tid)
+	}
+}
+
+// GenerateTraceId generates a new TraceID with a Pseudo-random number generator.
+//
+// The generator is seeded with the timestamp of the first time a new traceID is needed.
+func GenerateTraceId() TraceID {
+	if randSource == nil {
+		randSource = rand.New(rand.NewSource(time.Now().UnixNano()))
+	}
+
+	tid := TraceID{}
+	randSource.Read(tid[:])
+
+	return tid
+}
+
+// WithNewTraceId returns a copy of the passed context, with a newly generated traceID accessible for autometrics.
+func WithNewTraceId(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, currentTraceId, GenerateTraceId())
+}
+
+// FillBuildInfo adds the relevant build information to the current context.
+func (c *Context) FillBuildInfo() {
+	c.BuildInfo.Version = GetVersion()
+	c.BuildInfo.Commit = GetCommit()
+	c.BuildInfo.Branch = GetBranch()
+}

--- a/pkg/autometrics/main.go
+++ b/pkg/autometrics/main.go
@@ -1,9 +1,6 @@
 package autometrics // import "github.com/autometrics-dev/autometrics-go/pkg/autometrics"
 
 import (
-	"context"
-	"fmt"
-	"log"
 	"time"
 )
 
@@ -24,55 +21,15 @@ type Implementation int
 
 const (
 	PROMETHEUS Implementation = iota
-	OTEL                      = iota
+	OTEL
 )
 
-// Context holds the configuration
-// to instrument properly a function.
-//
-// This can be viewed as a context for the instrumentation calls
-type Context struct {
-	// TrackConcurrentCalls triggers the collection of the gauge for concurrent calls of the function.
-	TrackConcurrentCalls bool
-	// TrackCallerName adds a label with the caller name in all the collected metrics.
-	TrackCallerName bool
-	// AlertConf is an optional configuration to add alerting capabilities to the metrics.
-	AlertConf *AlertConfiguration
-	// StartTime is the start time of a single function execution.
-	// Only amImpl.Instrument should read this value.
-	// Only amImpl.PreInstrument should write this value.
-	//
-	// (amImpl is either the [Prometheus] or the [Open Telemetry] implementation)
-	//
-	// This value is only exported for the child packages [Prometheus] and [Open Telemetry]
-	//
-	// [Prometheus]: https://godoc.org/github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus
-	// [Open Telemetry]: https://godoc.org/github.com/autometrics-dev/autometrics-go/pkg/autometrics/otel
-	StartTime time.Time
-	// CallInfo contains all the relevant data for caller information.
-	// Only amImpl.Instrument should read this value.
-	// Only amImpl.PreInstrument should write/read this value.
-	//
-	// (amImpl is either the [Prometheus] or the [Open Telemetry] implementation)
-	//
-	// This value is only exported for the child packages [Prometheus] and [Open Telemetry]
-	//
-	// [Prometheus]: https://godoc.org/github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus
-	// [Open Telemetry]: https://godoc.org/github.com/autometrics-dev/autometrics-go/pkg/autometrics/otel
-	CallInfo CallInfo
-	// BuildInfo contains all the relevant data for caller information.
-	// Only amImpl.Instrument and PreInstrument should read this value.
-	// Only amImpl.Init should write/read this value.
-	//
-	// (amImpl is either the [Prometheus] or the [Open Telemetry] implementation)
-	//
-	// This value is only exported for the child packages [Prometheus] and [Open Telemetry]
-	//
-	// [Prometheus]: https://godoc.org/github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus
-	// [Open Telemetry]: https://godoc.org/github.com/autometrics-dev/autometrics-go/pkg/autometrics/otel
-	BuildInfo BuildInfo
-	Context   context.Context
-}
+const (
+	// MiddlewareSpanIDKey is the key to use to index context in middlewares that do not use context.Context.
+	MiddlewareSpanIDKey = "autometricsSpanID"
+	// MiddlewareTraceIDKey is the key to use to index context in middlewares that do not use context.Context.
+	MiddlewareTraceIDKey = "autometricsTraceID"
+)
 
 // CallInfo holds the information about the current function call and its parent names.
 type CallInfo struct {
@@ -94,77 +51,6 @@ type BuildInfo struct {
 	Version string
 	// Branch is the branch of the build of the codebase.
 	Branch string
-}
-
-func NewContext() Context {
-	return Context{
-		TrackConcurrentCalls: true,
-		TrackCallerName:      true,
-		AlertConf:            nil,
-		Context:              context.Background(),
-	}
-}
-
-func (c *Context) FillBuildInfo() {
-	c.BuildInfo.Version = GetVersion()
-	c.BuildInfo.Commit = GetCommit()
-	c.BuildInfo.Branch = GetBranch()
-}
-
-func (c Context) Validate(allowCustomLatencies bool) error {
-	if c.AlertConf != nil {
-		if c.AlertConf.ServiceName == "" {
-			return fmt.Errorf("Cannot have an AlertConfiguration without a service name")
-		}
-
-		if c.AlertConf.Success != nil && c.AlertConf.Success.Objective <= 0 {
-			return fmt.Errorf("Cannot have a target success rate that is negative")
-		}
-
-		if c.AlertConf.Success != nil && c.AlertConf.Success.Objective <= 1 {
-			log.Println("Warning: the target success rate is between 0 and 1, which is between 0 and 1%%. '1' is 1%% not 100%%!")
-		}
-
-		if c.AlertConf.Success != nil && c.AlertConf.Success.Objective > 100 {
-			return fmt.Errorf("Cannot have a target success rate that is strictly greater than 100 (more than 100%%)")
-		}
-
-		if c.AlertConf.Success != nil && !contains(DefObjectives, c.AlertConf.Success.Objective) {
-			return fmt.Errorf("Cannot have a target success rate that is not one of the predetermined ones by generated rules files (valid targets are %v)", DefObjectives)
-		}
-
-		if c.AlertConf.Latency != nil {
-			if c.AlertConf.Latency.Objective <= 0 {
-				return fmt.Errorf("Cannot have a target for latency SLO that is negative")
-			}
-			if c.AlertConf.Latency.Objective <= 1 {
-				log.Println("Warning: the latency target success rate is between 0 and 1, which is between 0 and 1%%. '1' is 1%% not 100%%!")
-			}
-			if c.AlertConf.Latency.Objective > 100 {
-				return fmt.Errorf("Cannot have a target for latency SLO that is greater than 100 (more than 100%%)")
-			}
-			if !contains(DefObjectives, c.AlertConf.Latency.Objective) {
-				return fmt.Errorf("Cannot have a target for latency SLO that is not one of the predetermined in the generated rules files (valid targets are %v)", DefObjectives)
-			}
-			if c.AlertConf.Latency.Target <= 0 {
-				return fmt.Errorf("Cannot have a target latency SLO threshold that is negative (responses expected before the query)")
-			}
-			if !allowCustomLatencies && !contains(DefBuckets, c.AlertConf.Latency.Target.Seconds()) {
-				return fmt.Errorf("Cannot have a target latency SLO threshold that does not match a bucket (valid threshold in seconds are %v). If you set custom latencies in your Init call, then you can add the %v flag to the //go:generate invocation to remove this error", DefBuckets, AllowCustomLatenciesFlag)
-			}
-		}
-	}
-
-	return nil
-}
-
-func contains[T comparable](s []T, e T) bool {
-	for _, v := range s {
-		if v == e {
-			return true
-		}
-	}
-	return false
 }
 
 // AlertConfiguration is the configuration for autometric alerting.

--- a/pkg/autometrics/middleware.go
+++ b/pkg/autometrics/middleware.go
@@ -1,0 +1,31 @@
+package autometrics // import "github.com/autometrics-dev/autometrics-go/pkg/autometrics"
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type autometricsResponseWriter struct {
+    http.ResponseWriter
+    statusCode int
+}
+
+func NewResponseWriter(w http.ResponseWriter) *autometricsResponseWriter {
+    return &autometricsResponseWriter{w, http.StatusOK}
+}
+
+func (amrw *autometricsResponseWriter) WriteHeader(code int) {
+    amrw.statusCode = code
+    amrw.ResponseWriter.WriteHeader(code)
+}
+
+// HasHttpError returns non-nil if the response writer is an autometrics wrapper,
+// and if the inner status code is outside of the 200-399 range.
+func HasHttpError(rw http.ResponseWriter) error {
+	if amrw, ok := rw.(*autometricsResponseWriter); ok {
+		if amrw.statusCode < 200 || amrw.statusCode >= 400 {
+			return fmt.Errorf("HTTP error %s (%d)", http.StatusText(amrw.statusCode), amrw.statusCode)
+		}
+	}
+	return nil
+}

--- a/pkg/autometrics/otel/ctx.go
+++ b/pkg/autometrics/otel/ctx.go
@@ -1,6 +1,7 @@
 package otel // import "github.com/autometrics-dev/autometrics-go/pkg/autometrics/otel"
 
 import (
+	"context"
 	"time"
 
 	"github.com/autometrics-dev/autometrics-go/pkg/autometrics"
@@ -12,14 +13,34 @@ func (fn optionFunc) Apply(ctx *autometrics.Context) {
 	fn(ctx)
 }
 
-func  NewContext(opts ...autometrics.Option) *autometrics.Context {
-	ctx := autometrics.NewContext()
+func NewContext(ctx context.Context, opts ...autometrics.Option) *autometrics.Context {
+	amCtx := autometrics.NewContext(ctx)
 
-	for _, o := range(opts) {
-		o.Apply(&ctx)
+	for _, o := range opts {
+		o.Apply(&amCtx)
 	}
 
-	return &ctx
+	return &amCtx
+}
+
+func WithTraceID(tid []byte) autometrics.Option {
+	return optionFunc(func(ctx *autometrics.Context) {
+		if tid != nil {
+			var truncatedTid autometrics.TraceID
+			copy(truncatedTid[:], tid)
+			ctx.SetTraceID(truncatedTid)
+		}
+	})
+}
+
+func WithSpanID(sid []byte) autometrics.Option {
+	return optionFunc(func(ctx *autometrics.Context) {
+		if sid != nil {
+			var truncatedSid autometrics.SpanID
+			copy(truncatedSid[:], sid)
+			ctx.SetSpanID(truncatedSid)
+		}
+	})
 }
 
 func WithAlertLatency(target time.Duration, objective float64) autometrics.Option {

--- a/pkg/autometrics/otel/instrument.go
+++ b/pkg/autometrics/otel/instrument.go
@@ -1,7 +1,6 @@
 package otel // import "github.com/autometrics-dev/autometrics-go/pkg/autometrics/otel"
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 	"time"
@@ -86,7 +85,7 @@ func Instrument(ctx *autometrics.Context, err *error) {
 func PreInstrument(ctx *autometrics.Context) *autometrics.Context {
 	ctx.CallInfo = autometrics.CallerInfo()
 	ctx.FillBuildInfo()
-	ctx.Context = context.Background()
+	ctx.FillTracingInfo()
 
 	var callerLabel string
 	if ctx.TrackCallerName {

--- a/pkg/autometrics/otel/utils.go
+++ b/pkg/autometrics/otel/utils.go
@@ -1,0 +1,22 @@
+package otel // import "github.com/autometrics-dev/autometrics-go/pkg/autometrics/otel"
+
+import (
+	"context"
+	"encoding/hex"
+
+	"github.com/autometrics-dev/autometrics-go/pkg/autometrics"
+)
+
+// Convenience re-export of [hex.DecodeString] to allow generating code without touching imports in instrumented file.
+func DecodeString(s string) []byte {
+	res, err := hex.DecodeString(s)
+	if err != nil {
+		return nil
+	}
+	return res
+}
+
+// Convenience re-export of [autometrics.WithNewTraceId] to avoid needing multiple imports in instrumented file.
+func WithNewTraceId(ctx context.Context) context.Context {
+	return autometrics.WithNewTraceId(ctx)
+}

--- a/pkg/autometrics/prometheus/ctx.go
+++ b/pkg/autometrics/prometheus/ctx.go
@@ -1,6 +1,7 @@
 package prometheus // import "github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus"
 
 import (
+	"context"
 	"time"
 
 	"github.com/autometrics-dev/autometrics-go/pkg/autometrics"
@@ -12,14 +13,34 @@ func (fn optionFunc) Apply(ctx *autometrics.Context) {
 	fn(ctx)
 }
 
-func NewContext(opts ...autometrics.Option) *autometrics.Context {
-	ctx := autometrics.NewContext()
+func NewContext(ctx context.Context, opts ...autometrics.Option) *autometrics.Context {
+	amCtx := autometrics.NewContext(ctx)
 
 	for _, o := range(opts) {
-		o.Apply(&ctx)
+		o.Apply(&amCtx)
 	}
 
-	return &ctx
+	return &amCtx
+}
+
+func WithTraceID(tid []byte) autometrics.Option {
+	return optionFunc(func(ctx *autometrics.Context) {
+		if tid != nil {
+			var truncatedTid autometrics.TraceID
+			copy(truncatedTid[:], tid)
+			ctx.SetTraceID(truncatedTid)
+		}
+	})
+}
+
+func WithSpanID(sid []byte) autometrics.Option {
+	return optionFunc(func(ctx *autometrics.Context) {
+		if sid != nil {
+			var truncatedSid autometrics.SpanID
+			copy(truncatedSid[:], sid)
+			ctx.SetSpanID(truncatedSid)
+		}
+	})
 }
 
 func WithAlertLatency(target time.Duration, objective float64) autometrics.Option {

--- a/pkg/autometrics/prometheus/prometheus.go
+++ b/pkg/autometrics/prometheus/prometheus.go
@@ -15,7 +15,7 @@ var (
 
 const (
 	// FunctionCallsCountName is the name of the prometheus metric for the counter of calls to specific functions.
-	FunctionCallsCountName = "function_calls_count"
+	FunctionCallsCountName = "function_calls_count_total"
 	// FunctionCallsDurationName is the name of the prometheus metric for the duration histogram of calls to specific functions.
 	FunctionCallsDurationName = "function_calls_duration"
 	// FunctionCallsConcurrentName is the name of the prometheus metric for the number of simulateneously active calls to specific functions.
@@ -59,6 +59,10 @@ const (
 	VersionLabel = "version"
 	// BranchLabel is the prometheus label that describes the branch of the build of the monitored codebase.
 	BranchLabel = "branch"
+
+	traceIdExemplar = "trace_id"
+	spanIdExemplar = "span_id"
+	parentSpanIdExemplar = "parent_id"
 )
 
 // BuildInfo holds meta information about the build of the instrumented code.

--- a/pkg/autometrics/prometheus/utils.go
+++ b/pkg/autometrics/prometheus/utils.go
@@ -1,0 +1,22 @@
+package prometheus // import "github.com/autometrics-dev/autometrics-go/pkg/autometrics/prometheus"
+
+import (
+	"context"
+	"encoding/hex"
+
+	"github.com/autometrics-dev/autometrics-go/pkg/autometrics"
+)
+
+// Convenience re-export of [hex.DecodeString] to allow generating code without touching imports in instrumented file.
+func DecodeString(s string) []byte {
+	res, err := hex.DecodeString(s)
+	if err != nil {
+		return nil
+	}
+	return res
+}
+
+// Convenience re-export of [autometrics.WithNewTraceId] to avoid needing multiple imports in instrumented file.
+func WithNewTraceId(ctx context.Context) context.Context {
+	return autometrics.WithNewTraceId(ctx)
+}


### PR DESCRIPTION
# Description

This PR has a big refactoring to make code generation easier to understand, and also adds the
ability for autometrics to track in a context the traceID and the spanID for the currently instrumented
function. This is built over a more generic mechanism to attach data to metrics using contexts.

Autometrics also uses its parser to detect common libraries/function signatures, in order to access the
context from instrumented code directly: this is necessary to have autometrics pick up the traceID/spanID
if it was injected by other means (like a middleware for the web framework being used).

Related to #44 as it is a first necessary step

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [ ] The CHANGELOG is updated.
- [ ] The open-telemetry example in repository works fine:
  + the docker compose file is valid
  + the application compiles and run
  + alerts are getting triggered in Prometheus
