### PR TITLE
Add autometrics imports when calling `go generate` if necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,22 @@ versioning](https://go.dev/doc/modules/version-numbers).
 
 ### Added
 
+- The Go generator now removes all the old defer statements in function bodies before re-adding
+  only the necessary ones. This means calling `go generate` on a file that has no annotation
+  at all effectively cleans up the whole file from autometrics.
+
 ### Changed
+
+- Instead of returning an error when the go generator does not find the autometrics import
+  in a file, it will add the needed import itself in the file.
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- Code generation now works when `autometrics` is imported with the `_` alias
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,11 @@ And then in your main function initialize the metrics
 	)
 ```
 
-### Add cookies in your code
+### Add directives in your code
+
+> **Warning**
+> You must both add the `//go:generate` directive, and one `//autometrics:inst`
+directive per function you want to instrument
 
 On top of each file you want to use Autometrics in, you need to have a `go generate` cookie:
 
@@ -82,8 +86,7 @@ On top of each file you want to use Autometrics in, you need to have a `go gener
 
 Then instrumenting functions depend on their signature:
 
-<details>
-<summary>For error-returning functions</summary>
+#### For error-returning functions
 Given a starting function like:
 
 ```go
@@ -107,10 +110,9 @@ func AddUser(args interface{}) (err error) { // Name the error return value; thi
 > If you want the generated metrics to contain the function success rate, you
 _must_ name the error return value. This is why we recommend to name the error
 value you return for the function you want to instrument.
-</details>
 
-<details>
-<summary>For HTTP handler functions</summary>
+
+#### For HTTP handler functions
 Autometrics comes with a middleware library for `net.http` handler functions.
 
 - Import the middleware library
@@ -136,7 +138,6 @@ import "github.com/autometrics-dev/autometrics-go/prometheus/midhttp"
 
 There is only middleware for `net/http` handlers for now, but support for other web frameworks will
 come soon!
-</details>
 
 ### Generate the documentation and instrumentation code
 

--- a/internal/generate/defer.go
+++ b/internal/generate/defer.go
@@ -60,6 +60,20 @@ func injectDeferStatement(ctx *internal.GeneratorContext, funcDeclaration *dst.F
 	return nil
 }
 
+// removeDeferStatement removes, if detected, a previously injected defer statement.
+func removeDeferStatement(ctx *internal.GeneratorContext, funcDeclaration *dst.FuncDecl) error {
+	firstStatement := funcDeclaration.Body.List[0]
+
+	if deferStatement, ok := firstStatement.(*dst.DeferStmt); ok {
+		decorations := deferStatement.Decorations().End
+		if slices.Contains(decorations.All(), "//autometrics:defer") {
+			funcDeclaration.Body.List = funcDeclaration.Body.List[1:]
+		}
+	}
+
+	return nil
+}
+
 // errorReturnValueName returns the name of the error return value if it exists.
 func errorReturnValueName(funcNode *dst.FuncDecl) (string, error) {
 	returnValues := funcNode.Type.Results

--- a/internal/generate/defer.go
+++ b/internal/generate/defer.go
@@ -204,6 +204,7 @@ func buildAutometricsDeferStatement(ctx *internal.GeneratorContext, secondVar st
 	statement.Decs.Before = dst.NewLine
 	statement.Decs.End = []string{"//autometrics:defer"}
 	statement.Decs.After = dst.EmptyLine
+
 	return statement, nil
 }
 

--- a/internal/generate/defer.go
+++ b/internal/generate/defer.go
@@ -108,32 +108,32 @@ func buildAutometricsContextNode(agc *internal.GeneratorContext) (*dst.CallExpr,
 	var options []string
 
 	if agc.RuntimeCtx.TraceIDGetter != "" {
-		options = append(options, fmt.Sprintf("%v.WithTraceID(%v)", agc.FuncCtx.ImplImportName, agc.RuntimeCtx.TraceIDGetter))
+		options = append(options, fmt.Sprintf("%vWithTraceID(%v)", autometricsNamespacePrefix(agc), agc.RuntimeCtx.TraceIDGetter))
 	}
 	if agc.RuntimeCtx.SpanIDGetter != "" {
-		options = append(options, fmt.Sprintf("%v.WithSpanID(%v)", agc.FuncCtx.ImplImportName, agc.RuntimeCtx.SpanIDGetter))
+		options = append(options, fmt.Sprintf("%vWithSpanID(%v)", autometricsNamespacePrefix(agc), agc.RuntimeCtx.SpanIDGetter))
 	}
 
 	options = append(options,
-		fmt.Sprintf("%v.WithConcurrentCalls(%#v)", agc.FuncCtx.ImplImportName, agc.RuntimeCtx.TrackConcurrentCalls),
-		fmt.Sprintf("%v.WithCallerName(%#v)", agc.FuncCtx.ImplImportName, agc.RuntimeCtx.TrackCallerName),
+		fmt.Sprintf("%vWithConcurrentCalls(%#v)", autometricsNamespacePrefix(agc), agc.RuntimeCtx.TrackConcurrentCalls),
+		fmt.Sprintf("%vWithCallerName(%#v)", autometricsNamespacePrefix(agc), agc.RuntimeCtx.TrackCallerName),
 	)
 
 	if agc.RuntimeCtx.AlertConf != nil {
-		options = append(options, fmt.Sprintf("%v.WithSloName(%#v)",
-			agc.FuncCtx.ImplImportName,
+		options = append(options, fmt.Sprintf("%vWithSloName(%#v)",
+			autometricsNamespacePrefix(agc),
 			agc.RuntimeCtx.AlertConf.ServiceName,
 		))
 		if agc.RuntimeCtx.AlertConf.Latency != nil {
-			options = append(options, fmt.Sprintf("%v.WithAlertLatency(%#v * time.Nanosecond, %#v)",
-				agc.FuncCtx.ImplImportName,
+			options = append(options, fmt.Sprintf("%vWithAlertLatency(%#v * time.Nanosecond, %#v)",
+				autometricsNamespacePrefix(agc),
 				agc.RuntimeCtx.AlertConf.Latency.Target,
 				agc.RuntimeCtx.AlertConf.Latency.Objective,
 			))
 		}
 		if agc.RuntimeCtx.AlertConf.Success != nil {
-			options = append(options, fmt.Sprintf("%v.WithAlertSuccess(%#v)",
-				agc.FuncCtx.ImplImportName,
+			options = append(options, fmt.Sprintf("%vWithAlertSuccess(%#v)",
+				autometricsNamespacePrefix(agc),
 				agc.RuntimeCtx.AlertConf.Success.Objective))
 		}
 	}
@@ -144,10 +144,10 @@ func buildAutometricsContextNode(agc *internal.GeneratorContext) (*dst.CallExpr,
 		`
 package main
 
-var dummy = %v.NewContext(
+var dummy = %vNewContext(
 	%s,
 `,
-		agc.FuncCtx.ImplImportName,
+		autometricsNamespacePrefix(agc),
 		agc.RuntimeCtx.ContextVariableName,
 	)
 	if err != nil {
@@ -202,10 +202,10 @@ func buildAutometricsDeferStatement(ctx *internal.GeneratorContext, secondVar st
 	}
 	statement := dst.DeferStmt{
 		Call: &dst.CallExpr{
-			Fun: dst.NewIdent(fmt.Sprintf("%v.Instrument", ctx.FuncCtx.ImplImportName)),
+			Fun: dst.NewIdent(fmt.Sprintf("%vInstrument", autometricsNamespacePrefix(ctx))),
 			Args: []dst.Expr{
 				&dst.CallExpr{
-					Fun: dst.NewIdent(fmt.Sprintf("%v.PreInstrument", ctx.FuncCtx.ImplImportName)),
+					Fun: dst.NewIdent(fmt.Sprintf("%vPreInstrument", autometricsNamespacePrefix(ctx))),
 					Args: []dst.Expr{
 						preInstrumentArg,
 					},
@@ -220,6 +220,14 @@ func buildAutometricsDeferStatement(ctx *internal.GeneratorContext, secondVar st
 	statement.Decs.After = dst.EmptyLine
 
 	return statement, nil
+}
+
+func autometricsNamespacePrefix(ctx *internal.GeneratorContext) string {
+	if ctx.FuncCtx.ImplImportName == "_" {
+		return ""
+	} else {
+		return fmt.Sprintf("%v.", ctx.FuncCtx.ImplImportName)
+	}
 }
 
 // detectContextIdentImpl is a Context detection logic helper for arguments whose type is an identifier

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -146,7 +146,13 @@ func walkFuncDeclaration(ctx *internal.GeneratorContext, funcDeclaration *dst.Fu
 		return fmt.Errorf("error trying to remove autometrics comment from former pass: %w", err)
 	}
 
-	// TODO: clean up the defer statement inconditionally here as well, if detected
+	err = removeDeferStatement(ctx, funcDeclaration)
+	if err != nil {
+		return fmt.Errorf(
+			"error removing an older autometrics defer statement in %v: %w",
+			funcDeclaration.Name.Name,
+			err)
+	}
 
 	// Detect autometrics directive
 	err = parseAutometricsFnContext(ctx, docComments)

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -33,52 +33,53 @@ func main() {
 }
 `
 
-	want := "// This is the package comment.\n" +
-		"package main\n" +
-		"\n" +
-		"import (\n" +
-		"\tprom \"github.com/autometrics-dev/autometrics-go/prometheus/autometrics\"\n" +
-		")\n" +
-		"\n" +
-		"// This comment is associated with the main function.\n" +
-		"//\n" +
-		"//\tautometrics:doc-start Generated documentation by Autometrics.\n" +
-		"//\n" +
-		"// # Autometrics\n" +
-		"//\n" +
-		"// # Prometheus\n" +
-		"//\n" +
-		"// View the live metrics for the `main` function:\n" +
-		"//   - [Request Rate]\n" +
-		"//   - [Error Ratio]\n" +
-		"//   - [Latency (95th and 99th percentiles)]\n" +
-		"//   - [Concurrent Calls]\n" +
-		"//\n" +
-		"// Or, dig into the metrics of *functions called by* `main`\n" +
-		"//   - [Request Rate Callee]\n" +
-		"//   - [Error Ratio Callee]\n" +
-		"//\n" +
-		"//\tautometrics:doc-end Generated documentation by Autometrics.\n" +
-		"//\n" +
-		"// [Request Rate]: http://localhost:9090/graph?g0.expr=%23+Rate+of+calls+to+the+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0\n" +
-		"// [Error Ratio]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+calls+to+the+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0A%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bfunction%3D%22main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29+%2F+%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29&g0.tab=0\n" +
-		"// [Latency (95th and 99th percentiles)]: http://localhost:9090/graph?g0.expr=%23+95th+and+99th+percentile+latencies+%28in+seconds%29+for+the+%60main%60+function%0A%0Alabel_replace%28histogram_quantile%280.99%2C+sum+by+%28le%2C+function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29%2C+%22percentile_latency%22%2C+%2299%22%2C+%22%22%2C+%22%22%29+or+label_replace%28histogram_quantile%280.95%2C+sum+by+%28le%2C+function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29%2C%22percentile_latency%22%2C+%2295%22%2C+%22%22%2C+%22%22%29&g0.tab=0\n" +
-		"// [Concurrent Calls]: http://localhost:9090/graph?g0.expr=%23+Concurrent+calls+to+the+%60main%60+function%0A%0Asum+by+%28function%2C+module%2C+version%2C+commit%29+%28function_calls_concurrent%7Bfunction%3D%22main%22%7D+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0\n" +
-		"// [Request Rate Callee]: http://localhost:9090/graph?g0.expr=%23+Rate+of+function+calls+emanating+from+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bcaller%3D%22main.main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0\n" +
-		"// [Error Ratio Callee]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+function+emanating+from+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0A%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bcaller%3D%22main.main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29+%2F+%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bcaller%3D%22main.main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29&g0.tab=0\n" +
-		"//\n" +
-		"//autometrics:inst --slo \"Service Test\" --success-target 99\n" +
-		"func main() {\n" +
-		"\tdefer prom.Instrument(prom.PreInstrument(prom.NewContext(\n" +
-		"\t\tnil,\n" +
-		"\t\tprom.WithConcurrentCalls(true),\n" +
-		"\t\tprom.WithCallerName(true),\n" +
-		"\t\tprom.WithSloName(\"Service Test\"),\n" +
-		"\t\tprom.WithAlertSuccess(99),\n" +
-		"\t)), nil) //autometrics:defer\n" +
-		"\n" +
-		"	fmt.Println(hello) // line comment 3\n" +
-		"}\n"
+	want := `// This is the package comment.
+package main
+
+import (
+	prom "github.com/autometrics-dev/autometrics-go/prometheus/autometrics"
+)
+
+// This comment is associated with the main function.
+//
+//	autometrics:doc-start Generated documentation by Autometrics.
+//
+// # Autometrics
+//
+// # Prometheus
+//
+// View the live metrics for the `+"`main`"+` function:
+//   - [Request Rate]
+//   - [Error Ratio]
+//   - [Latency (95th and 99th percentiles)]
+//   - [Concurrent Calls]
+//
+// Or, dig into the metrics of *functions called by* `+"`main`"+`
+//   - [Request Rate Callee]
+//   - [Error Ratio Callee]
+//
+//	autometrics:doc-end Generated documentation by Autometrics.
+//
+// [Request Rate]: http://localhost:9090/graph?g0.expr=%23+Rate+of+calls+to+the+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0
+// [Error Ratio]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+calls+to+the+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0A%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bfunction%3D%22main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29+%2F+%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29&g0.tab=0
+// [Latency (95th and 99th percentiles)]: http://localhost:9090/graph?g0.expr=%23+95th+and+99th+percentile+latencies+%28in+seconds%29+for+the+%60main%60+function%0A%0Alabel_replace%28histogram_quantile%280.99%2C+sum+by+%28le%2C+function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29%2C+%22percentile_latency%22%2C+%2299%22%2C+%22%22%2C+%22%22%29+or+label_replace%28histogram_quantile%280.95%2C+sum+by+%28le%2C+function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29%2C%22percentile_latency%22%2C+%2295%22%2C+%22%22%2C+%22%22%29&g0.tab=0
+// [Concurrent Calls]: http://localhost:9090/graph?g0.expr=%23+Concurrent+calls+to+the+%60main%60+function%0A%0Asum+by+%28function%2C+module%2C+version%2C+commit%29+%28function_calls_concurrent%7Bfunction%3D%22main%22%7D+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0
+// [Request Rate Callee]: http://localhost:9090/graph?g0.expr=%23+Rate+of+function+calls+emanating+from+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bcaller%3D%22main.main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0
+// [Error Ratio Callee]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+function+emanating+from+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0A%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bcaller%3D%22main.main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29+%2F+%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bcaller%3D%22main.main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29&g0.tab=0
+//
+//autometrics:inst --slo "Service Test" --success-target 99
+func main() {
+	defer prom.Instrument(prom.PreInstrument(prom.NewContext(
+		nil,
+		prom.WithConcurrentCalls(true),
+		prom.WithCallerName(true),
+		prom.WithSloName("Service Test"),
+		prom.WithAlertSuccess(99),
+	)), nil) //autometrics:defer
+
+	fmt.Println(hello) // line comment 3
+}
+`
 
 	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
 	if err != nil {
@@ -118,52 +119,53 @@ func main() {
 }
 `
 
-	want := "// This is the package comment.\n" +
-		"package main\n" +
-		"\n" +
-		"import (\n" +
-		"\tprom \"github.com/autometrics-dev/autometrics-go/prometheus/autometrics\"\n" +
-		")\n" +
-		"\n" +
-		"// This comment is associated with the main function.\n" +
-		"//\n" +
-		"//\tautometrics:doc-start Generated documentation by Autometrics.\n" +
-		"//\n" +
-		"// # Autometrics\n" +
-		"//\n" +
-		"// # Prometheus\n" +
-		"//\n" +
-		"// View the live metrics for the `main` function:\n" +
-		"//   - [Request Rate]\n" +
-		"//   - [Error Ratio]\n" +
-		"//   - [Latency (95th and 99th percentiles)]\n" +
-		"//   - [Concurrent Calls]\n" +
-		"//\n" +
-		"// Or, dig into the metrics of *functions called by* `main`\n" +
-		"//   - [Request Rate Callee]\n" +
-		"//   - [Error Ratio Callee]\n" +
-		"//\n" +
-		"//\tautometrics:doc-end Generated documentation by Autometrics.\n" +
-		"//\n" +
-		"// [Request Rate]: http://localhost:9090/graph?g0.expr=%23+Rate+of+calls+to+the+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0\n" +
-		"// [Error Ratio]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+calls+to+the+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0A%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bfunction%3D%22main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29+%2F+%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29&g0.tab=0\n" +
-		"// [Latency (95th and 99th percentiles)]: http://localhost:9090/graph?g0.expr=%23+95th+and+99th+percentile+latencies+%28in+seconds%29+for+the+%60main%60+function%0A%0Alabel_replace%28histogram_quantile%280.99%2C+sum+by+%28le%2C+function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29%2C+%22percentile_latency%22%2C+%2299%22%2C+%22%22%2C+%22%22%29+or+label_replace%28histogram_quantile%280.95%2C+sum+by+%28le%2C+function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29%2C%22percentile_latency%22%2C+%2295%22%2C+%22%22%2C+%22%22%29&g0.tab=0\n" +
-		"// [Concurrent Calls]: http://localhost:9090/graph?g0.expr=%23+Concurrent+calls+to+the+%60main%60+function%0A%0Asum+by+%28function%2C+module%2C+version%2C+commit%29+%28function_calls_concurrent%7Bfunction%3D%22main%22%7D+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0\n" +
-		"// [Request Rate Callee]: http://localhost:9090/graph?g0.expr=%23+Rate+of+function+calls+emanating+from+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bcaller%3D%22main.main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0\n" +
-		"// [Error Ratio Callee]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+function+emanating+from+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0A%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bcaller%3D%22main.main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29+%2F+%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bcaller%3D%22main.main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29&g0.tab=0\n" +
-		"//\n" +
-		"//autometrics:inst --slo \"API\" --latency-target 99.9 --latency-ms 500\n" +
-		"func main() {\n" +
-		"\tdefer prom.Instrument(prom.PreInstrument(prom.NewContext(\n" +
-		"\t\tnil,\n" +
-		"\t\tprom.WithConcurrentCalls(true),\n" +
-		"\t\tprom.WithCallerName(true),\n" +
-		"\t\tprom.WithSloName(\"API\"),\n" +
-		"\t\tprom.WithAlertLatency(500000000*time.Nanosecond, 99.9),\n" +
-		"\t)), nil) //autometrics:defer\n" +
-		"\n" +
-		"	fmt.Println(hello) // line comment 3\n" +
-		"}\n"
+	want := `// This is the package comment.
+package main
+
+import (
+	prom "github.com/autometrics-dev/autometrics-go/prometheus/autometrics"
+)
+
+// This comment is associated with the main function.
+//
+//	autometrics:doc-start Generated documentation by Autometrics.
+//
+// # Autometrics
+//
+// # Prometheus
+//
+// View the live metrics for the `+"`main`"+` function:
+//   - [Request Rate]
+//   - [Error Ratio]
+//   - [Latency (95th and 99th percentiles)]
+//   - [Concurrent Calls]
+//
+// Or, dig into the metrics of *functions called by* `+"`main`"+`
+//   - [Request Rate Callee]
+//   - [Error Ratio Callee]
+//
+//	autometrics:doc-end Generated documentation by Autometrics.
+//
+// [Request Rate]: http://localhost:9090/graph?g0.expr=%23+Rate+of+calls+to+the+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0
+// [Error Ratio]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+calls+to+the+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0A%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bfunction%3D%22main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29+%2F+%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29&g0.tab=0
+// [Latency (95th and 99th percentiles)]: http://localhost:9090/graph?g0.expr=%23+95th+and+99th+percentile+latencies+%28in+seconds%29+for+the+%60main%60+function%0A%0Alabel_replace%28histogram_quantile%280.99%2C+sum+by+%28le%2C+function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29%2C+%22percentile_latency%22%2C+%2299%22%2C+%22%22%2C+%22%22%29+or+label_replace%28histogram_quantile%280.95%2C+sum+by+%28le%2C+function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_duration_bucket%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29%2C%22percentile_latency%22%2C+%2295%22%2C+%22%22%2C+%22%22%29&g0.tab=0
+// [Concurrent Calls]: http://localhost:9090/graph?g0.expr=%23+Concurrent+calls+to+the+%60main%60+function%0A%0Asum+by+%28function%2C+module%2C+version%2C+commit%29+%28function_calls_concurrent%7Bfunction%3D%22main%22%7D+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0
+// [Request Rate Callee]: http://localhost:9090/graph?g0.expr=%23+Rate+of+function+calls+emanating+from+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bcaller%3D%22main.main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0
+// [Error Ratio Callee]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+function+emanating+from+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0A%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bcaller%3D%22main.main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29+%2F+%28sum+by+%28function%2C+module%2C+version%2C+commit%29+%28rate%28function_calls_count_total%7Bcaller%3D%22main.main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29&g0.tab=0
+//
+//autometrics:inst --slo "API" --latency-target 99.9 --latency-ms 500
+func main() {
+	defer prom.Instrument(prom.PreInstrument(prom.NewContext(
+		nil,
+		prom.WithConcurrentCalls(true),
+		prom.WithCallerName(true),
+		prom.WithSloName("API"),
+		prom.WithAlertLatency(500000000*time.Nanosecond, 99.9),
+	)), nil) //autometrics:defer
+
+	fmt.Println(hello) // line comment 3
+}
+`
 
 	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
 	if err != nil {
@@ -192,26 +194,26 @@ func main() {
 }
 `
 
-	want := "// This is the package comment.\n" +
-		"package main\n" +
-		"\n" +
-		"import " +
-		"\"github.com/autometrics-dev/autometrics-go/prometheus/autometrics\"\n" +
-		"\n" +
-		"// This comment is associated with the main function.\n" +
-		"//\n" +
-		"//autometrics:inst --no-doc --slo \"API\" --latency-target 99.9 --latency-ms 500\n" +
-		"func main() {\n" +
-		"\tdefer autometrics.Instrument(autometrics.PreInstrument(autometrics.NewContext(\n" +
-		"\t\tnil,\n" +
-		"\t\tautometrics.WithConcurrentCalls(true),\n" +
-		"\t\tautometrics.WithCallerName(true),\n" +
-		"\t\tautometrics.WithSloName(\"API\"),\n" +
-		"\t\tautometrics.WithAlertLatency(500000000*time.Nanosecond, 99.9),\n" +
-		"\t)), nil) //autometrics:defer\n" +
-		"\n" +
-		"	fmt.Println(hello) // line comment 3\n" +
-		"}\n"
+	want := `// This is the package comment.
+package main
+
+import "github.com/autometrics-dev/autometrics-go/prometheus/autometrics"
+
+// This comment is associated with the main function.
+//
+//autometrics:inst --no-doc --slo "API" --latency-target 99.9 --latency-ms 500
+func main() {
+	defer autometrics.Instrument(autometrics.PreInstrument(autometrics.NewContext(
+		nil,
+		autometrics.WithConcurrentCalls(true),
+		autometrics.WithCallerName(true),
+		autometrics.WithSloName("API"),
+		autometrics.WithAlertLatency(500000000*time.Nanosecond, 99.9),
+	)), nil) //autometrics:defer
+
+	fmt.Println(hello) // line comment 3
+}
+`
 
 	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
 	if err != nil {
@@ -245,29 +247,30 @@ func main() {
 }
 `
 
-	want := "// This is the package comment.\n" +
-		"package main\n" +
-		"\n" +
-		"import (\n" +
-		"\t\"fmt\"\n" +
-		"\t\"github.com/autometrics-dev/autometrics-go/prometheus/autometrics\"\n" +
-		"\t\"strings\"\n" +
-		")\n" +
-		"\n" +
-		"// This comment is associated with the main function.\n" +
-		"//\n" +
-		"//autometrics:inst --no-doc --slo \"API\" --latency-target 99.9 --latency-ms 500\n" +
-		"func main() {\n" +
-		"\tdefer autometrics.Instrument(autometrics.PreInstrument(autometrics.NewContext(\n" +
-		"\t\tnil,\n" +
-		"\t\tautometrics.WithConcurrentCalls(true),\n" +
-		"\t\tautometrics.WithCallerName(true),\n" +
-		"\t\tautometrics.WithSloName(\"API\"),\n" +
-		"\t\tautometrics.WithAlertLatency(500000000*time.Nanosecond, 99.9),\n" +
-		"\t)), nil) //autometrics:defer\n" +
-		"\n" +
-		"	fmt.Println(hello) // line comment 3\n" +
-		"}\n"
+	want := `// This is the package comment.
+package main
+
+import (
+	"fmt"
+	"github.com/autometrics-dev/autometrics-go/prometheus/autometrics"
+	"strings"
+)
+
+// This comment is associated with the main function.
+//
+//autometrics:inst --no-doc --slo "API" --latency-target 99.9 --latency-ms 500
+func main() {
+	defer autometrics.Instrument(autometrics.PreInstrument(autometrics.NewContext(
+		nil,
+		autometrics.WithConcurrentCalls(true),
+		autometrics.WithCallerName(true),
+		autometrics.WithSloName("API"),
+		autometrics.WithAlertLatency(500000000*time.Nanosecond, 99.9),
+	)), nil) //autometrics:defer
+
+	fmt.Println(hello) // line comment 3
+}
+`
 
 	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
 	if err != nil {
@@ -306,25 +309,25 @@ func main() {
 }
 `
 
-	want := "// This is the package comment.\n" +
-		"package main\n" +
-		"\n" +
-		"import " +
-		"\"github.com/autometrics-dev/autometrics-go/prometheus/autometrics\"\n" +
-		"\n" +
-		"// This comment is associated with the main function.\n" +
-		"//autometrics:inst --no-doc --slo \"API\" --latency-target 99.9 --latency-ms 500\n" +
-		"func main() {\n" +
-		"\tdefer autometrics.Instrument(autometrics.PreInstrument(autometrics.NewContext(\n" +
-		"\t\tnil,\n" +
-		"\t\tautometrics.WithConcurrentCalls(true),\n" +
-		"\t\tautometrics.WithCallerName(true),\n" +
-		"\t\tautometrics.WithSloName(\"API\"),\n" +
-		"\t\tautometrics.WithAlertLatency(500000000*time.Nanosecond, 99.9),\n" +
-		"\t)), nil) //autometrics:defer\n" +
-		"\n" +
-		"	fmt.Println(hello) // line comment 3\n" +
-		"}\n"
+	want := `// This is the package comment.
+package main
+
+import "github.com/autometrics-dev/autometrics-go/prometheus/autometrics"
+
+// This comment is associated with the main function.
+//autometrics:inst --no-doc --slo "API" --latency-target 99.9 --latency-ms 500
+func main() {
+	defer autometrics.Instrument(autometrics.PreInstrument(autometrics.NewContext(
+		nil,
+		autometrics.WithConcurrentCalls(true),
+		autometrics.WithCallerName(true),
+		autometrics.WithSloName("API"),
+		autometrics.WithAlertLatency(500000000*time.Nanosecond, 99.9),
+	)), nil) //autometrics:defer
+
+	fmt.Println(hello) // line comment 3
+}
+`
 
 	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
 	if err != nil {
@@ -366,28 +369,29 @@ func main() {
 }
 `
 
-	want := "// This is the package comment.\n" +
-		"package main\n" +
-		"\n" +
-		"import (\n" +
-		"\t\"github.com/autometrics-dev/autometrics-go/pkg/autometrics\"\n" +
-		"\tprom \"github.com/autometrics-dev/autometrics-go/prometheus/autometrics\"\n" +
-		")\n" +
-		"\n" +
-		"// This comment is associated with the main function.\n" +
-		"//\n" +
-		"//autometrics:inst --slo \"API\" --latency-target 99.9 --latency-ms 500\n" +
-		"func main() {\n" +
-		"\tdefer prom.Instrument(prom.PreInstrument(prom.NewContext(\n" +
-		"\t\tnil,\n" +
-		"\t\tprom.WithConcurrentCalls(true),\n" +
-		"\t\tprom.WithCallerName(true),\n" +
-		"\t\tprom.WithSloName(\"API\"),\n" +
-		"\t\tprom.WithAlertLatency(500000000*time.Nanosecond, 99.9),\n" +
-		"\t)), nil) //autometrics:defer\n" +
-		"\n" +
-		"	fmt.Println(hello) // line comment 3\n" +
-		"}\n"
+	want := `// This is the package comment.
+package main
+
+import (
+	"github.com/autometrics-dev/autometrics-go/pkg/autometrics"
+	prom "github.com/autometrics-dev/autometrics-go/prometheus/autometrics"
+)
+
+// This comment is associated with the main function.
+//
+//autometrics:inst --slo "API" --latency-target 99.9 --latency-ms 500
+func main() {
+	defer prom.Instrument(prom.PreInstrument(prom.NewContext(
+		nil,
+		prom.WithConcurrentCalls(true),
+		prom.WithCallerName(true),
+		prom.WithSloName("API"),
+		prom.WithAlertLatency(500000000*time.Nanosecond, 99.9),
+	)), nil) //autometrics:defer
+
+	fmt.Println(hello) // line comment 3
+}
+`
 
 	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
 	if err != nil {

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -48,13 +48,13 @@ import (
 //
 // # Prometheus
 //
-// View the live metrics for the `+"`main`"+` function:
+// View the live metrics for the ` + "`main`" + ` function:
 //   - [Request Rate]
 //   - [Error Ratio]
 //   - [Latency (95th and 99th percentiles)]
 //   - [Concurrent Calls]
 //
-// Or, dig into the metrics of *functions called by* `+"`main`"+`
+// Or, dig into the metrics of *functions called by* ` + "`main`" + `
 //   - [Request Rate Callee]
 //   - [Error Ratio Callee]
 //
@@ -134,13 +134,13 @@ import (
 //
 // # Prometheus
 //
-// View the live metrics for the `+"`main`"+` function:
+// View the live metrics for the ` + "`main`" + ` function:
 //   - [Request Rate]
 //   - [Error Ratio]
 //   - [Latency (95th and 99th percentiles)]
 //   - [Concurrent Calls]
 //
-// Or, dig into the metrics of *functions called by* `+"`main`"+`
+// Or, dig into the metrics of *functions called by* ` + "`main`" + `
 //   - [Request Rate Callee]
 //   - [Error Ratio Callee]
 //

--- a/internal/generate/imports.go
+++ b/internal/generate/imports.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dave/dst"
 )
 
+// inspectImportSpec builds the context's ImportMap with the new import, and returns whether an autometrics import exists.
 func inspectImportSpec(ctx *internal.GeneratorContext, importSpec *dst.ImportSpec) bool {
 	var foundAm bool
 
@@ -49,6 +50,7 @@ func inspectImportSpec(ctx *internal.GeneratorContext, importSpec *dst.ImportSpe
 	return foundAm
 }
 
+// addAutometricsImport adds the correct autometrics import to the passed fileTree.
 func addAutometricsImport(ctx *internal.GeneratorContext, fileTree *dst.File) error {
 	// var importSpec dst.ImportSpec
 	if ctx.Implementation == autometrics.PROMETHEUS {
@@ -74,6 +76,8 @@ func addAutometricsImport(ctx *internal.GeneratorContext, fileTree *dst.File) er
 	return errors.New("unrecognized implementation of Autometrics has been queried")
 }
 
+// addImport walks a file declarations to add in the correct location an additional import for 'imp' without alias.
+//
 // Ref: https://github.com/dave/dst/issues/61#issuecomment-928529830
 func addImport(file *dst.File, imp string) {
 	// Where to insert our import block within the file's Decl slice

--- a/internal/generate/imports.go
+++ b/internal/generate/imports.go
@@ -1,0 +1,137 @@
+package generate // import "github.com/autometrics-dev/autometrics-go/internal/generate"
+
+import (
+	"errors"
+	"fmt"
+	"go/token"
+	"strconv"
+	"strings"
+
+	internal "github.com/autometrics-dev/autometrics-go/internal/autometrics"
+	"github.com/autometrics-dev/autometrics-go/pkg/autometrics"
+
+	"github.com/dave/dst"
+)
+
+func inspectImportSpec(ctx *internal.GeneratorContext, importSpec *dst.ImportSpec) bool {
+	var foundAm bool
+
+	if ctx.Implementation == autometrics.PROMETHEUS {
+		if importSpec.Path.Value == AmPromPackage {
+			if importSpec.Name != nil {
+				ctx.FuncCtx.ImplImportName = importSpec.Name.Name
+			} else {
+				ctx.FuncCtx.ImplImportName = "autometrics"
+			}
+			foundAm = true
+		}
+	}
+
+	if ctx.Implementation == autometrics.OTEL {
+		if importSpec.Path.Value == AmOtelPackage {
+			if importSpec.Name != nil {
+				ctx.FuncCtx.ImplImportName = importSpec.Name.Name
+			} else {
+				ctx.FuncCtx.ImplImportName = "autometrics"
+			}
+			foundAm = true
+		}
+	}
+
+	if importSpec.Name == nil {
+		names := strings.Split(importSpec.Path.Value, "/")
+		name := strings.Trim(names[len(names)-1], "\"")
+		ctx.ImportsMap[name] = strings.Trim(importSpec.Path.Value, "\"")
+	} else {
+		ctx.ImportsMap[importSpec.Name.Name] = strings.Trim(importSpec.Path.Value, "\"")
+	}
+
+	return foundAm
+}
+
+func addAutometricsImport(ctx *internal.GeneratorContext, fileTree *dst.File) error {
+	// var importSpec dst.ImportSpec
+	if ctx.Implementation == autometrics.PROMETHEUS {
+		addImport(fileTree, mustUnquote(AmPromPackage))
+		ctx.FuncCtx.ImplImportName = "autometrics"
+		ctx.ImportsMap["autometrics"] = AmPromPackage
+
+		return nil
+	}
+
+	if ctx.Implementation == autometrics.OTEL {
+		addImport(fileTree, mustUnquote(AmOtelPackage))
+		ctx.FuncCtx.ImplImportName = "autometrics"
+		ctx.ImportsMap["autometrics"] = AmOtelPackage
+
+		return nil
+	}
+
+	if ctx.FuncCtx.ImplImportName == "" {
+		return errors.New("assertion error: ctx.FuncCtx.ImplImportName is empty at the end of addAutometricsImport")
+	}
+
+	return errors.New("unrecognized implementation of Autometrics has been queried")
+}
+
+// Ref: https://github.com/dave/dst/issues/61#issuecomment-928529830
+func addImport(file *dst.File, imp string) {
+	// Where to insert our import block within the file's Decl slice
+	index := 0
+
+	importSpec := &dst.ImportSpec{
+		Path: &dst.BasicLit{Kind: token.STRING, Value: fmt.Sprintf("%q", imp)},
+	}
+
+	for i, node := range file.Decls {
+		n, ok := node.(*dst.GenDecl)
+		if !ok {
+			continue
+		}
+
+		if n.Tok != token.IMPORT {
+			continue
+		}
+
+		if len(n.Specs) == 1 && mustUnquote(n.Specs[0].(*dst.ImportSpec).Path.Value) == "C" {
+			// If we're going to insert, it must be after the "C" import
+			index = i + 1
+			continue
+		}
+
+		// Insert our import into the first non-"C" import block
+		for j, spec := range n.Specs {
+			path := mustUnquote(spec.(*dst.ImportSpec).Path.Value)
+			if !strings.Contains(path, ".") || imp > path {
+				continue
+			}
+
+			importSpec.Decorations().Before = spec.Decorations().Before
+			spec.Decorations().Before = dst.NewLine
+
+			n.Specs = append(n.Specs[:j], append([]dst.Spec{importSpec}, n.Specs[j:]...)...)
+			return
+		}
+
+		n.Specs = append(n.Specs, importSpec)
+		return
+	}
+
+	gd := &dst.GenDecl{
+		Tok:   token.IMPORT,
+		Specs: []dst.Spec{importSpec},
+		Decs: dst.GenDeclDecorations{
+			NodeDecs: dst.NodeDecs{Before: dst.EmptyLine, After: dst.EmptyLine},
+		},
+	}
+
+	file.Decls = append(file.Decls[:index], append([]dst.Decl{gd}, file.Decls[index:]...)...)
+}
+
+func mustUnquote(s string) string {
+	out, err := strconv.Unquote(s)
+	if err != nil {
+		panic(err)
+	}
+	return out
+}


### PR DESCRIPTION
# Description

Allows the generator to work around editors automatically removing "unused imports" on save

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] The CHANGELOG is updated.
- [x] The open-telemetry example in repository works fine:
  + the docker compose file is valid
  + the application compiles and run
  + alerts are getting triggered in Prometheus
- [x] The prometheus example in repository works fine:
  + the docker compose file is valid
  + the application compiles and run
  + alerts are getting triggered in Prometheus
  + exemplars are accessible on the graph
