### PR TITLE
Add Prometheus instructions and AM reference to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,25 @@ This is the shortest way to initialize and expose the metrics that autometrics w
 in the generated code.
 </details>
 
-A Prometheus server can be configured to poll the application, and the autometrics will be
-available! (See the [Web App example](./examples/web) for a simple, complete setup)
+A Prometheus server can be configured to poll the application, and the autometrics will be available! (See the [Web App example](./examples/web) for a simple, complete setup)
+
+### Run Prometheus locally to validate and preview the data
+
+You can use the open source Autometrics CLI to run automatically configured Prometheus locally to see the metrics that will be registered by the change. See the [Autometrics CLI docs](https://docs.autometrics.dev/local-development#getting-started-with-am) for more information.
+
+or you can configure Prometheus manually:
+
+```yaml
+scrape_configs:
+  - job_name: my-app
+    metrics_path: /metrics # the endpoint you configured your metrics exporter on (usually /metrics)
+    static_configs:
+      - targets: ['localhost:<PORT>'] # The port your service is on
+    scrape_interval: 200ms
+    # For a real deployment, you would want the scrape interval to be
+    # longer but for testing, you want the data to show up quickly
+```
+
 
 ## (OPTIONAL) Generate alerts automatically
 


### PR DESCRIPTION
# Description

This update adds a small para to the README explaining how to spin up Prometheus locally (with `am`)

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- ~~[ ] The CHANGELOG is updated.~~
- ~~[ ] The open-telemetry example in repository works fine:~~
  + the docker compose file is valid
  + the application compiles and run
  + alerts are getting triggered in Prometheus
- ~~[ ] The prometheus example in repository works fine:~~
  + the docker compose file is valid
  + the application compiles and run
  + alerts are getting triggered in Prometheus
  + exemplars are accessible on the graph
