### PR TITLE
Add --inst-all and --rm-all options to generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ versioning](https://go.dev/doc/modules/version-numbers).
 
 ### Added
 
+- [All] `autometrics` the go-generator binary accepts an `--inst-all` flag, to process all
+  functions in the file even if they do not have any annotation
+- [All] `autometrics` the go-generator binary accepts a `--rm-all` flag (that overrides the `--inst-all` flag)
+  to remove autometrics from all annotated functions. This is useful to offboard autometrics after trying it:
+  ```bash
+  AM_RM_ALL=true go generate ./...  # Will remove all godoc and instrumentation calls
+  sed -i '/\/\/.*autometrics/d' **/*.go   # A similar sed command will remove all comments containing 'autometrics'
+  # A go linter/formatter of your choice can then clean up all unused imports to remove the automatically added ones.
+  ```
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ versioning](https://go.dev/doc/modules/version-numbers).
 
 ### Added
 
-- [All] `autometrics` the go-generator binary accepts an `--inst-all` flag, to process all
+- [All] `autometrics` the go-generator binary accepts an `--instrument-all` flag, to process all
   functions in the file even if they do not have any annotation
-- [All] `autometrics` the go-generator binary accepts a `--rm-all` flag (that overrides the `--inst-all` flag)
+- [All] `autometrics` the go-generator binary accepts a `--rm-all` flag (that overrides the `--instrument-all` flag)
   to remove autometrics from all annotated functions. This is useful to offboard autometrics after trying it:
   ```bash
   AM_RM_ALL=true go generate ./...  # Will remove all godoc and instrumentation calls

--- a/README.md
+++ b/README.md
@@ -116,6 +116,28 @@ compatibility comes out of the box).
 
 ### 3. Add directives for each function you want to instrument
 
+#### 3a. The VERY quick way
+
+Use find and sed to insert a `//go:generate` directive that will instrument all
+the functions in all source files under the current directory:
+
+(Replace `gsed` with `sed` on linux; `gsed` is installed with `brew gsed`)
+
+``` bash
+find . \
+ -type f \
+ -path ./vendor -prune -or \
+ -name '*.go*' \
+ -print0 | xargs -0 gsed -i -e '/package/{a\//go:generate autometrics --instrument-all --no-doc' -e ':a;n;ba}'
+```
+
+You can remove the `--no-doc` to get the full experience, but the generator will add a lot of comments if so.
+
+#### 3b. The slower quick way
+
+This grants you more control over what gets instrumented, but it is longer
+to add.
+
 > **Warning**
 > You must both add the `//go:generate` directive, and one `//autometrics:inst`
 directive per function you want to instrument
@@ -133,7 +155,7 @@ subsection to see details:
 
 Once it is done, you can call the [generator](#4-generate-the-documentation-and-instrumentation-code)
 
-#### For error-returning functions
+##### For error-returning functions
 
 <details><summary><i>Expand to instrument error returning functions</i></summary>
 
@@ -165,7 +187,7 @@ _must_ name the error return value. This is why we recommend to name the error
 value you return for the function you want to instrument.
 </details>
 
-#### For HTTP handler functions
+##### For HTTP handler functions
 
 <details><summary><i>Expand to instrument HTTP handlers functions</i></summary>
 
@@ -477,6 +499,23 @@ instrumentation only, you have multiple options:
 $ AM_NO_DOCGEN=true go generate ./...
 ```
 
+##### Offboarding
+
+If for some reason you want to stop using autometrics, the easiest way includes 3 steps.
+
+First is to use the environment variable `AM_RM_ALL` to remove all generated documentation
+and code:
+
+``` console
+$ AM_RM_ALL=true go generate ./...
+```
+
+Second step is to use grep/your text-editor/your IDE of choice to remove all lines starting with
+`//go:generate autometrics` from your files so `go generate` will stop creating autometrics code.
+
+Last step is to use your text-editor IDE to remove remnants:
+- a "go imports" cleaner to remove the `autometrics` imports (or grep-ing again)
+- remove the `autometrics.Init` call from the main entrypoint of your code.
 
 # Contributing
 

--- a/cmd/autometrics/main.go
+++ b/cmd/autometrics/main.go
@@ -24,7 +24,7 @@ type args struct {
 	UseOtel              bool   `arg:"--otel" default:"false" help:"Use OpenTelemetry client library to instrument code instead of default Prometheus."`
 	AllowCustomLatencies bool   `arg:"--custom-latency" default:"false" help:"Allow non-default latencies to be used in latency-based SLOs."`
 	DisableDocGeneration bool   `arg:"--no-doc,env:AM_NO_DOCGEN" default:"false" help:"Disable documentation links generation for all instrumented functions. Has the same effect as --no-doc in the //autometrics:inst directive."`
-	ProcessAllFunctions  bool   `arg:"--inst-all,env:AM_INST_ALL" default:"false" help:"Instrument all function declared in the file to transform. Overwritten by the --rm-all argument if both are set."`
+	ProcessAllFunctions  bool   `arg:"--instrument-all,env:AM_INSTRUMENT_ALL" default:"false" help:"Instrument all function declared in the file to transform. Overwritten by the --rm-all argument if both are set."`
 	RemoveAllFunctions   bool   `arg:"--rm-all,env:AM_RM_ALL" default:"false" help:"Remove all function instrumentation in the file to transform."`
 }
 

--- a/cmd/autometrics/main.go
+++ b/cmd/autometrics/main.go
@@ -24,6 +24,8 @@ type args struct {
 	UseOtel              bool   `arg:"--otel" default:"false" help:"Use OpenTelemetry client library to instrument code instead of default Prometheus."`
 	AllowCustomLatencies bool   `arg:"--custom-latency" default:"false" help:"Allow non-default latencies to be used in latency-based SLOs."`
 	DisableDocGeneration bool   `arg:"--no-doc,env:AM_NO_DOCGEN" default:"false" help:"Disable documentation links generation for all instrumented functions. Has the same effect as --no-doc in the //autometrics:inst directive."`
+	ProcessAllFunctions  bool   `arg:"--inst-all,env:AM_INST_ALL" default:"false" help:"Instrument all function declared in the file to transform. Overwritten by the --rm-all argument if both are set."`
+	RemoveAllFunctions   bool   `arg:"--rm-all,env:AM_RM_ALL" default:"false" help:"Remove all function instrumentation in the file to transform."`
 }
 
 func (args) Version() string {
@@ -69,6 +71,8 @@ func main() {
 		args.PrometheusUrl,
 		args.AllowCustomLatencies,
 		args.DisableDocGeneration,
+		args.ProcessAllFunctions,
+		args.RemoveAllFunctions,
 	)
 	if err != nil {
 		log.Fatalf("error initialising autometrics context: %s", err)

--- a/cmd/autometrics/main.go
+++ b/cmd/autometrics/main.go
@@ -24,7 +24,7 @@ type args struct {
 	UseOtel              bool   `arg:"--otel" default:"false" help:"Use OpenTelemetry client library to instrument code instead of default Prometheus."`
 	AllowCustomLatencies bool   `arg:"--custom-latency" default:"false" help:"Allow non-default latencies to be used in latency-based SLOs."`
 	DisableDocGeneration bool   `arg:"--no-doc,env:AM_NO_DOCGEN" default:"false" help:"Disable documentation links generation for all instrumented functions. Has the same effect as --no-doc in the //autometrics:inst directive."`
-	ProcessAllFunctions  bool   `arg:"--instrument-all,env:AM_INSTRUMENT_ALL" default:"false" help:"Instrument all function declared in the file to transform. Overwritten by the --rm-all argument if both are set."`
+	ProcessAllFunctions  bool   `arg:"-i,--instrument-all,--inst-all,env:AM_INSTRUMENT_ALL" default:"false" help:"Instrument all function declared in the file to transform. Overwritten by the --rm-all argument if both are set."`
 	RemoveAllFunctions   bool   `arg:"--rm-all,env:AM_RM_ALL" default:"false" help:"Remove all function instrumentation in the file to transform."`
 }
 

--- a/internal/autometrics/ctx.go
+++ b/internal/autometrics/ctx.go
@@ -30,6 +30,12 @@ type GeneratorContext struct {
 	//
 	// This can be set in the command for the generator or through the environment.
 	DisableDocGeneration bool
+	// Flag to ask the generator to process all function declaration even if they
+	// do not have any annotation. The flag is overriden by the RemoveEverything one.
+	InstrumentEverything bool
+	// Flag to ask the generator to only remove all autometrics generated code in the
+	// file.
+	RemoveEverything bool
 	// ImportMap maps the alias to import in the current file, to canonical names associated with that name.
 	ImportsMap map[string]string
 }
@@ -143,11 +149,13 @@ func (c *GeneratorContext) SetCommentIdx(i int) {
 	c.FuncCtx.CommentIndex = i
 }
 
-func NewGeneratorContext(implementation autometrics.Implementation, prometheusUrl string, allowCustomLatencies, disableDocGeneration bool) (GeneratorContext, error) {
+func NewGeneratorContext(implementation autometrics.Implementation, prometheusUrl string, allowCustomLatencies, disableDocGeneration, instrumentEverything, removeEverything bool) (GeneratorContext, error) {
 	ctx := GeneratorContext{
 		Implementation:       implementation,
 		AllowCustomLatencies: allowCustomLatencies,
 		DisableDocGeneration: disableDocGeneration,
+		InstrumentEverything: instrumentEverything,
+		RemoveEverything:     removeEverything,
 		RuntimeCtx:           DefaultRuntimeCtxInfo(),
 		FuncCtx:              GeneratorFunctionContext{},
 		ImportsMap:           make(map[string]string),

--- a/internal/generate/defer_test.go
+++ b/internal/generate/defer_test.go
@@ -53,7 +53,7 @@ func main(thisIsAContext context.Context) {
 		"	fmt.Println(hello) // line comment 3\n" +
 		"}\n"
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -110,7 +110,7 @@ func main(thisIsAContext vanilla.Context) {
 		"	fmt.Println(hello) // line comment 3\n" +
 		"}\n"
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -167,7 +167,7 @@ func main(thisIsAContext Context) {
 		"	fmt.Println(hello) // line comment 3\n" +
 		"}\n"
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -224,7 +224,7 @@ func main(w http.ResponseWriter, req *http.Request) {
 		"	fmt.Println(hello) // line comment 3\n" +
 		"}\n"
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -281,7 +281,7 @@ func main(w vanilla.ResponseWriter, req *vanilla.Request) {
 		"	fmt.Println(hello) // line comment 3\n" +
 		"}\n"
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -338,7 +338,7 @@ func main(w ResponseWriter, req *Request) {
 		"	fmt.Println(hello) // line comment 3\n" +
 		"}\n"
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -395,7 +395,7 @@ func main(thisIsAContext buffalo.Context) {
 		"	fmt.Println(hello) // line comment 3\n" +
 		"}\n"
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -452,7 +452,7 @@ func main(thisIsAContext vanilla.Context) {
 		"	fmt.Println(hello) // line comment 3\n" +
 		"}\n"
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -509,7 +509,7 @@ func main(thisIsAContext Context) {
 		"	fmt.Println(hello) // line comment 3\n" +
 		"}\n"
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -568,7 +568,7 @@ func main(thisIsAContext echo.Context) {
 		"	fmt.Println(hello) // line comment 3\n" +
 		"}\n"
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -627,7 +627,7 @@ func main(thisIsAContext vanilla.Context) {
 		"	fmt.Println(hello) // line comment 3\n" +
 		"}\n"
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -686,7 +686,7 @@ func main(thisIsAContext Context) {
 		"	fmt.Println(hello) // line comment 3\n" +
 		"}\n"
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -745,7 +745,7 @@ func main(thisIsAContext *gin.Context) {
 		"	fmt.Println(hello) // line comment 3\n" +
 		"}\n"
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -804,7 +804,7 @@ func main(thisIsAContext *vanilla.Context) {
 		"	fmt.Println(hello) // line comment 3\n" +
 		"}\n"
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -863,7 +863,7 @@ func main(thisIsAContext *Context) {
 		"	fmt.Println(hello) // line comment 3\n" +
 		"}\n"
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -81,7 +81,7 @@ func main() {
 }
 `
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -160,7 +160,7 @@ func main() {
 }
 `
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -211,7 +211,121 @@ func main() {
 }
 `
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false, false, false)
+	if err != nil {
+		t.Fatalf("error creating the generation context: %s", err)
+	}
+
+	actual, err := GenerateDocumentationAndInstrumentation(ctx, sourceCode, "main")
+	if err != nil {
+		t.Fatalf("error generating the documentation: %s", err)
+	}
+
+	assert.Equal(t, want, actual, "The generated source code is not as expected.")
+}
+
+func TestInstrumentEverything(t *testing.T) {
+	sourceCode := `// This is the package comment.
+package main
+
+import (
+	prom "github.com/autometrics-dev/autometrics-go/prometheus/autometrics"
+)
+
+func main() {
+	fmt.Println(hello) // line comment 3
+}
+`
+
+	want := `// This is the package comment.
+package main
+
+import (
+	prom "github.com/autometrics-dev/autometrics-go/prometheus/autometrics"
+)
+
+// main
+//
+//	autometrics:doc-start Generated documentation by Autometrics.
+//
+// # Autometrics
+//
+// # Prometheus
+//
+// View the live metrics for the ` + "`main`" + ` function:
+//   - [Request Rate]
+//   - [Error Ratio]
+//   - [Latency (95th and 99th percentiles)]
+//   - [Concurrent Calls]
+//
+// Or, dig into the metrics of *functions called by* ` + "`main`" + `
+//   - [Request Rate Callee]
+//   - [Error Ratio Callee]
+//
+//	autometrics:doc-end Generated documentation by Autometrics.
+//
+// [Request Rate]: http://localhost:9090/graph?g0.expr=%23+Rate+of+calls+to+the+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%2C+service_name%2C+version%2C+commit%29+%28rate%28function_calls_total%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0
+// [Error Ratio]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+calls+to+the+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0A%28sum+by+%28function%2C+module%2C+service_name%2C+version%2C+commit%29+%28rate%28function_calls_total%7Bfunction%3D%22main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29+%2F+%28sum+by+%28function%2C+module%2C+service_name%2C+version%2C+commit%29+%28rate%28function_calls_total%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29&g0.tab=0
+// [Latency (95th and 99th percentiles)]: http://localhost:9090/graph?g0.expr=%23+95th+and+99th+percentile+latencies+%28in+seconds%29+for+the+%60main%60+function%0A%0Alabel_replace%28histogram_quantile%280.99%2C+sum+by+%28le%2C+function%2C+module%2C+service_name%2C+version%2C+commit%29+%28rate%28function_calls_duration_seconds_bucket%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29%2C+%22percentile_latency%22%2C+%2299%22%2C+%22%22%2C+%22%22%29+or+label_replace%28histogram_quantile%280.95%2C+sum+by+%28le%2C+function%2C+module%2C+service_name%2C+version%2C+commit%29+%28rate%28function_calls_duration_seconds_bucket%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29%2C%22percentile_latency%22%2C+%2295%22%2C+%22%22%2C+%22%22%29&g0.tab=0
+// [Concurrent Calls]: http://localhost:9090/graph?g0.expr=%23+Concurrent+calls+to+the+%60main%60+function%0A%0Asum+by+%28function%2C+module%2C+service_name%2C+version%2C+commit%29+%28function_calls_concurrent%7Bfunction%3D%22main%22%7D+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0
+// [Request Rate Callee]: http://localhost:9090/graph?g0.expr=%23+Rate+of+function+calls+emanating+from+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%2C+service_name%2C+version%2C+commit%29+%28rate%28function_calls_total%7Bcaller_function%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0
+// [Error Ratio Callee]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+function+emanating+from+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0A%28sum+by+%28function%2C+module%2C+service_name%2C+version%2C+commit%29+%28rate%28function_calls_total%7Bcaller_function%3D%22main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29+%2F+%28sum+by+%28function%2C+module%2C+service_name%2C+version%2C+commit%29+%28rate%28function_calls_total%7Bcaller_function%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29&g0.tab=0
+func main() {
+	defer prom.Instrument(prom.PreInstrument(prom.NewContext(
+		nil,
+		prom.WithConcurrentCalls(true),
+		prom.WithCallerName(true),
+	)), nil) //autometrics:defer
+
+	fmt.Println(hello) // line comment 3
+}
+`
+
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false, true, false)
+	if err != nil {
+		t.Fatalf("error creating the generation context: %s", err)
+	}
+
+	actual, err := GenerateDocumentationAndInstrumentation(ctx, sourceCode, "main")
+	if err != nil {
+		t.Fatalf("error generating the documentation: %s", err)
+	}
+
+	assert.Equal(t, want, actual, "The generated source code is not as expected.")
+}
+
+func TestInstrumentEverythingNoDoc(t *testing.T) {
+	sourceCode := `// This is the package comment.
+package main
+
+import (
+	prom "github.com/autometrics-dev/autometrics-go/prometheus/autometrics"
+)
+
+func main() {
+	fmt.Println(hello) // line comment 3
+}
+`
+
+	want := `// This is the package comment.
+package main
+
+import (
+	prom "github.com/autometrics-dev/autometrics-go/prometheus/autometrics"
+)
+
+func main() {
+	defer prom.Instrument(prom.PreInstrument(prom.NewContext(
+		nil,
+		prom.WithConcurrentCalls(true),
+		prom.WithCallerName(true),
+	)), nil) //autometrics:defer
+
+	fmt.Println(hello) // line comment 3
+}
+`
+
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true, true, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -259,7 +373,7 @@ func main() {
 }
 `
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -270,6 +384,84 @@ func main() {
 	}
 
 	assert.Equal(t, want, actual, "The generated source code is not as expected.")
+}
+
+func TestCommentRemove(t *testing.T) {
+	sourceCode := `// This is the package comment.
+package main
+
+import (
+	prom "github.com/autometrics-dev/autometrics-go/prometheus/autometrics"
+)
+
+// This comment is associated with the main function.
+//
+//	autometrics:doc-start Generated documentation by Autometrics.
+//
+// # Autometrics
+//
+// # Prometheus
+//
+// View the live metrics for the ` + "`main`" + ` function:
+//   - [Request Rate]
+//   - [Error Ratio]
+//   - [Latency (95th and 99th percentiles)]
+//   - [Concurrent Calls]
+//
+// Or, dig into the metrics of *functions called by* ` + "`main`" + `
+//   - [Request Rate Callee]
+//   - [Error Ratio Callee]
+//
+//	autometrics:doc-end Generated documentation by Autometrics.
+//
+// [Request Rate]: http://localhost:9090/graph?g0.expr=%23+Rate+of+calls+to+the+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%2C+service_name%2C+version%2C+commit%29+%28rate%28function_calls_total%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0
+// [Error Ratio]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+calls+to+the+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0A%28sum+by+%28function%2C+module%2C+service_name%2C+version%2C+commit%29+%28rate%28function_calls_total%7Bfunction%3D%22main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29+%2F+%28sum+by+%28function%2C+module%2C+service_name%2C+version%2C+commit%29+%28rate%28function_calls_total%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29&g0.tab=0
+// [Latency (95th and 99th percentiles)]: http://localhost:9090/graph?g0.expr=%23+95th+and+99th+percentile+latencies+%28in+seconds%29+for+the+%60main%60+function%0A%0Alabel_replace%28histogram_quantile%280.99%2C+sum+by+%28le%2C+function%2C+module%2C+service_name%2C+version%2C+commit%29+%28rate%28function_calls_duration_seconds_bucket%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29%2C+%22percentile_latency%22%2C+%2299%22%2C+%22%22%2C+%22%22%29+or+label_replace%28histogram_quantile%280.95%2C+sum+by+%28le%2C+function%2C+module%2C+service_name%2C+version%2C+commit%29+%28rate%28function_calls_duration_seconds_bucket%7Bfunction%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29%2C%22percentile_latency%22%2C+%2295%22%2C+%22%22%2C+%22%22%29&g0.tab=0
+// [Concurrent Calls]: http://localhost:9090/graph?g0.expr=%23+Concurrent+calls+to+the+%60main%60+function%0A%0Asum+by+%28function%2C+module%2C+service_name%2C+version%2C+commit%29+%28function_calls_concurrent%7Bfunction%3D%22main%22%7D+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0
+// [Request Rate Callee]: http://localhost:9090/graph?g0.expr=%23+Rate+of+function+calls+emanating+from+%60main%60+function+per+second%2C+averaged+over+5+minute+windows%0A%0Asum+by+%28function%2C+module%2C+service_name%2C+version%2C+commit%29+%28rate%28function_calls_total%7Bcaller_function%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29&g0.tab=0
+// [Error Ratio Callee]: http://localhost:9090/graph?g0.expr=%23+Percentage+of+function+emanating+from+%60main%60+function+that+return+errors%2C+averaged+over+5+minute+windows%0A%0A%28sum+by+%28function%2C+module%2C+service_name%2C+version%2C+commit%29+%28rate%28function_calls_total%7Bcaller_function%3D%22main%22%2Cresult%3D%22error%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29+%2F+%28sum+by+%28function%2C+module%2C+service_name%2C+version%2C+commit%29+%28rate%28function_calls_total%7Bcaller_function%3D%22main%22%7D%5B5m%5D%29+%2A+on+%28instance%2C+job%29+group_left%28version%2C+commit%29+last_over_time%28build_info%5B1s%5D%29%29%29&g0.tab=0
+//
+//autometrics:inst --slo "API" --latency-target 99.9 --latency-ms 500
+func main() {
+	fmt.Println(hello) // line comment 3
+}
+`
+
+	want := `// This is the package comment.
+package main
+
+import (
+	prom "github.com/autometrics-dev/autometrics-go/prometheus/autometrics"
+)
+
+// This comment is associated with the main function.
+//
+//autometrics:inst --slo "API" --latency-target 99.9 --latency-ms 500
+func main() {
+	fmt.Println(hello) // line comment 3
+}
+`
+
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false, false, true)
+	if err != nil {
+		t.Fatalf("error creating the generation context: %s", err)
+	}
+	ctxWithBothFlags, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false, true, true)
+	if err != nil {
+		t.Fatalf("error creating the generation context: %s", err)
+	}
+
+	actual, err := GenerateDocumentationAndInstrumentation(ctx, sourceCode, "main")
+	if err != nil {
+		t.Fatalf("error generating the documentation: %s", err)
+	}
+	actualWithBothFlags, err := GenerateDocumentationAndInstrumentation(ctxWithBothFlags, sourceCode, "main")
+	if err != nil {
+		t.Fatalf("error generating the documentation: %s", err)
+	}
+
+	assert.Equal(t, want, actual, "The generated source code is not as expected.")
+	assert.Equal(t, want, actualWithBothFlags, "The generated source code when both InstrumentAll and RemoveAll are set is not as expected.")
 }
 
 // TestCommentRefresh calls GenerateDocumentationAndInstrumentation on a
@@ -345,7 +537,7 @@ func main() {
 }
 `
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -393,7 +585,7 @@ func main() {
 }
 `
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -450,7 +642,7 @@ func main() {
 }
 `
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -507,7 +699,7 @@ func main() {
 }
 `
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -571,7 +763,7 @@ func main() {
 }
 `
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, true, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -600,7 +792,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -623,7 +815,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
+	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -645,7 +837,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
+	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -670,7 +862,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -693,7 +885,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
+	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -716,7 +908,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
+	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -739,7 +931,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
+	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -762,7 +954,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
+	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -785,7 +977,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
+	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -808,7 +1000,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
+	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -816,7 +1008,7 @@ func main() {
 	_, err = GenerateDocumentationAndInstrumentation(ctx, sourceCode, "main")
 	assert.Error(t, err, "Calling generation must fail if latency target is not in the default buckets.")
 
-	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, true, false)
+	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, true, false, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -844,7 +1036,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -868,7 +1060,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
+	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -894,7 +1086,7 @@ func main() {
 	fmt.Printstart ln(hello) // line comment 3
 }
 `
-	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
+	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -920,7 +1112,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
+	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -945,7 +1137,7 @@ func main() {
 	fmt.Println(hello) // line comment 3
 }
 `
-	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
+	ctx, err = internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}
@@ -1346,7 +1538,7 @@ func main() {
 }
 `
 
-	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false)
+	ctx, err := internal.NewGeneratorContext(autometrics.PROMETHEUS, defaultPrometheusInstanceUrl, false, false, false, false)
 	if err != nil {
 		t.Fatalf("error creating the generation context: %s", err)
 	}


### PR DESCRIPTION
# Description

These speed up the migration to/from autometrics for bigger, established codebases.

Fixes #72

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] The CHANGELOG is updated.
- [x] The open-telemetry example in repository works fine:
  + the docker compose file is valid
  + the application compiles and run
  + alerts are getting triggered in Prometheus
- [x] The prometheus example in repository works fine:
  + the docker compose file is valid
  + the application compiles and run
  + alerts are getting triggered in Prometheus
  + exemplars are accessible on the graph
