### PR TITLE
Fix quickstart instruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,9 @@ versioning](https://go.dev/doc/modules/version-numbers).
 
 ### Added
 
-- [All] `autometrics` the go-generator binary accepts an `--instrument-all` flag, to process all
+- [All] `autometrics` the go-generator binary accepts an `--inst-all` flag, to process all
   functions in the file even if they do not have any annotation
-- [All] `autometrics` the go-generator binary accepts a `--rm-all` flag (that overrides the `--instrument-all` flag)
+- [All] `autometrics` the go-generator binary accepts a `--rm-all` flag (that overrides the `--inst-all` flag)
   to remove autometrics from all annotated functions. This is useful to offboard autometrics after trying it:
   ```bash
   AM_RM_ALL=true go generate ./...  # Will remove all godoc and instrumentation calls

--- a/README.md
+++ b/README.md
@@ -116,7 +116,12 @@ compatibility comes out of the box).
 
 ### 3. Add directives for each function you want to instrument
 
-#### 3a. The VERY quick way
+#### 3a. The QUICKEST way
+
+If you have [`am`](https://github.com/autometrics-dev/am) installed in version `0.6.0` or later, you can
+use `am instrumtent single -e /vendor/ -l go .` to instrument everything (excluding a possible `/vendor` subdirectory)
+
+#### 3b. The VERY quick way
 
 Use find and sed to insert a `//go:generate` directive that will instrument all
 the functions in all source files under the current directory:
@@ -125,15 +130,14 @@ the functions in all source files under the current directory:
 
 ``` bash
 find . \
- -type f \
- -path ./vendor -prune -or \
- -name '*.go*' \
- -print0 | xargs -0 gsed -i -e '/package/{a\//go:generate autometrics --instrument-all --no-doc' -e ':a;n;ba}'
+  -type d -name vendor -prune -or \
+  -type f -name '*.go' \
+  -print0 | xargs -0 gsed -i -e '/package/{a\//go:generate autometrics --inst-all --no-doc' -e ':a;n;ba}'
 ```
 
 You can remove the `--no-doc` to get the full experience, but the generator will add a lot of comments if so.
 
-#### 3b. The slower quick way
+#### 3c. The slower quick way
 
 This grants you more control over what gets instrumented, but it is longer
 to add.

--- a/cmd/autometrics/main.go
+++ b/cmd/autometrics/main.go
@@ -24,7 +24,7 @@ type args struct {
 	UseOtel              bool   `arg:"--otel" default:"false" help:"Use OpenTelemetry client library to instrument code instead of default Prometheus."`
 	AllowCustomLatencies bool   `arg:"--custom-latency" default:"false" help:"Allow non-default latencies to be used in latency-based SLOs."`
 	DisableDocGeneration bool   `arg:"--no-doc,env:AM_NO_DOCGEN" default:"false" help:"Disable documentation links generation for all instrumented functions. Has the same effect as --no-doc in the //autometrics:inst directive."`
-	ProcessAllFunctions  bool   `arg:"-i,--instrument-all,--inst-all,env:AM_INSTRUMENT_ALL" default:"false" help:"Instrument all function declared in the file to transform. Overwritten by the --rm-all argument if both are set."`
+	ProcessAllFunctions  bool   `arg:"-i,--inst-all,env:AM_INSTRUMENT_ALL" default:"false" help:"Instrument all function declared in the file to transform. Overwritten by the --rm-all argument if both are set."`
 	RemoveAllFunctions   bool   `arg:"--rm-all,env:AM_RM_ALL" default:"false" help:"Remove all function instrumentation in the file to transform."`
 }
 


### PR DESCRIPTION
# Description

Apparently go-arg doesn't work with flag aliases

# Checklist

n/a

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->
