### PR TITLE
Release 1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Go module
 versioning](https://go.dev/doc/modules/version-numbers).
 
-## [Unreleased](https://github.com/autometrics-dev/autometrics-go/compare/v1.0.0...main)
+## [Unreleased](https://github.com/autometrics-dev/autometrics-go/compare/v1.1.0...main)
 
 ### Added
 
@@ -18,10 +18,15 @@ versioning](https://go.dev/doc/modules/version-numbers).
 
 ### Fixed
 
+### Security
+
+## [1.1.0](https://github.com/autometrics-dev/autometrics-go/releases/tag/v1.1.0) 2024-01-25
+
+### Fixed
+
 - [All] Fixes an issue where the caller function name is badly reported as a random slice of the
   current function name (#85)
 
-### Security
 
 ## [1.0.0](https://github.com/autometrics-dev/autometrics-go/releases/tag/v1.0.0) 2023-12-01
 

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1,7 +1,7 @@
 package build // import "github.com/autometrics-dev/autometrics-go/internal/build"
 
 // Version is the version string of the build, when made available through ldflags.
-var Version = "1.0.0"
+var Version = "1.1.0"
 
 // User is the user who triggered this build, when made available through ldflags.
 var User = "n/a"


### PR DESCRIPTION
# Release <Version Number>

- [x] The `CHANGELOG` is updated with a new section and the correct links
- [x] The `Version` value in `internal/build` package is updated

Once this PR is merged, the commit must have a matching tag in the repository, 
and a corresponding release must be created in Github. If no other PR is merged
after this one, it is possible to do both steps in one go by creating the release
from Github UI. Otherwise, put the tag on the correct commit first, and do
the release "from an existing tag".
